### PR TITLE
harden: Tier B — password policy, OAuth identity linking, 500 redaction, role cycles, upload deny, realtime limits

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -567,6 +567,19 @@ export const initCommand = (cli: CAC) => {
             try {
               const authService = civic.getAuthService();
 
+              // Enforce the password policy on the bootstrap admin — the
+              // inline min-6 prompt check above is weaker than the policy
+              // (default: 8 + upper/lower/number/special).
+              const policy = authService.validatePasswordPolicy(
+                adminDetails.password
+              );
+              if (!policy.valid) {
+                logger.error(
+                  `Admin password does not meet requirements: ${policy.errors.join('; ')}`
+                );
+                process.exit(1);
+              }
+
               // Hash the password
               const bcrypt = await import('bcrypt');
               const passwordHash = await bcrypt.hash(adminDetails.password, 12);

--- a/cli/src/commands/users.ts
+++ b/cli/src/commands/users.ts
@@ -147,6 +147,19 @@ export default function setupUsersCommand(cli: CAC) {
           process.exit(1);
         }
 
+        // Enforce the configured password policy — the interactive prompt's
+        // inline length check is bypassed entirely when --password is passed.
+        const policy = authService.validatePasswordPolicy(password);
+        if (!policy.valid) {
+          cliError(
+            `Password does not meet requirements: ${policy.errors.join('; ')}`,
+            'WEAK_PASSWORD',
+            { errors: policy.errors },
+            'users:create'
+          );
+          process.exit(1);
+        }
+
         // Hash password
         const bcrypt = await import('bcrypt');
         const saltRounds = 12;
@@ -362,6 +375,19 @@ export default function setupUsersCommand(cli: CAC) {
                 details:
                   'Password management is handled by the external provider',
               },
+              'users:update'
+            );
+            process.exit(1);
+          }
+
+          // Enforce the configured password policy (users:update hashes
+          // inline, so PasswordOps never sees the plaintext).
+          const policy = authService.validatePasswordPolicy(password);
+          if (!policy.valid) {
+            cliError(
+              `Password does not meet requirements: ${policy.errors.join('; ')}`,
+              'WEAK_PASSWORD',
+              { errors: policy.errors },
               'users:update'
             );
             process.exit(1);

--- a/core/src/auth/auth-config.ts
+++ b/core/src/auth/auth-config.ts
@@ -272,7 +272,16 @@ export class AuthConfigManager {
   }
 
   validatePassword(password: string): { valid: boolean; errors: string[] } {
-    const requirements = this.getPasswordRequirements();
+    // Enforceable from ANY context: CLI commands reach this before anything
+    // calls loadConfig(). Failing open would skip the policy; throwing
+    // breaks the command — fall back to the compiled-in defaults instead
+    // (same posture as PasswordOps.getThrottle).
+    let requirements: AuthConfig['password'];
+    try {
+      requirements = this.getPasswordRequirements();
+    } catch {
+      requirements = this.getDefaultConfig().password;
+    }
     const errors: string[] = [];
 
     if (password.length < requirements.minLength) {

--- a/core/src/auth/auth-service.ts
+++ b/core/src/auth/auth-service.ts
@@ -634,6 +634,13 @@ export class AuthService {
   // SECURE PASSWORD MANAGEMENT (delegated to PasswordOps)
   // ===============================
 
+  /** Single password-policy chokepoint (see PasswordOps). */
+  validatePasswordPolicy(
+    ...args: Parameters<PasswordOps['validatePasswordPolicy']>
+  ): ReturnType<PasswordOps['validatePasswordPolicy']> {
+    return this.passwordOps.validatePasswordPolicy(...args);
+  }
+
   /**
    * Change user password with security guards
    */

--- a/core/src/auth/auth-service/oauth-ops.ts
+++ b/core/src/auth/auth-service/oauth-ops.ts
@@ -62,50 +62,22 @@ export interface OAuthOpsDeps {
 export class OAuthOps {
   constructor(private readonly deps: OAuthOpsDeps) {}
 
+  /**
+   * GitHub-specific entry point. Delegates to authenticateWithOAuth so it
+   * shares the SAME provider-identity matching — never re-introduces the
+   * username-based account takeover this used to have. (Currently no live
+   * caller uses it; POST /login goes through authenticateWithOAuth
+   * directly. Kept as a thin, safe alias rather than a divergent copy.)
+   */
   async authenticateWithGitHub(
     token: string
   ): Promise<{ token: string; user: AuthUser; expiresAt: Date }> {
-    try {
-      const githubUser = await this.deps.oauthManager.validateToken(
-        'github',
-        token
-      );
-
-      // Check if user exists, create if not
-      let user = await this.deps.getUserByUsername(githubUser.username);
-      if (!user) {
-        const defaultRole = await this.deps.getDefaultRole();
-        user = await this.deps.createUser({
-          username: githubUser.username,
-          role: defaultRole,
-          email: githubUser.email,
-          name: githubUser.name,
-          avatar_url: githubUser.avatar_url,
-        });
-      }
-
-      // Create session
-      const { token: sessionToken, session } = await this.deps.createSession(
-        user.id
-      );
-
-      // Log authentication event
-      await this.deps.logAuthEvent(
-        user.id,
-        'github_login',
-        `GitHub login for user ${user.username}`,
-        'github'
-      );
-
-      return {
-        token: sessionToken,
-        user,
-        expiresAt: session.expiresAt,
-      };
-    } catch (error) {
-      this.deps.logger?.error('GitHub authentication failed:', error);
-      throw new Error('GitHub authentication failed');
-    }
+    const result = await this.authenticateWithOAuth('github', token);
+    return {
+      token: result.token,
+      user: result.user,
+      expiresAt: result.expiresAt,
+    };
   }
 
   async authenticateWithOAuth(
@@ -145,17 +117,23 @@ export class OAuthOps {
         const byUsername = await this.deps.db.getUserByUsername(
           oauthUser.username
         );
-        if (
-          byUsername &&
+        // Legacy-account adoption matches by USERNAME, so it is only safe
+        // when the provider gave us a stable id to bind. A provider that
+        // returns no subject (a future misconfigured OIDC/SAML) must never
+        // adopt an existing account by username alone — that is the exact
+        // takeover path this fix closes.
+        const canAdopt =
+          !!providerUserId &&
+          !!byUsername &&
           byUsername.auth_provider === provider &&
-          !byUsername.provider_user_id
-        ) {
-          // Legacy adoption: an account this provider created BEFORE
-          // provider_user_id existed — bind the identity below. Anything
-          // else holding this username (a local/password account, another
-          // provider's, or a same-provider account bound to a DIFFERENT
-          // identity) must NOT be linked.
-          matchedId = byUsername.id;
+          !byUsername.provider_user_id;
+        if (canAdopt) {
+          // An account this provider created BEFORE provider_user_id
+          // existed — bind the identity below. Anything else holding this
+          // username (a local/password account, another provider's, or a
+          // same-provider account bound to a DIFFERENT identity) must NOT
+          // be linked.
+          matchedId = byUsername!.id;
         } else {
           // Create a fresh account; de-conflict the username when a
           // non-linkable account already holds it.

--- a/core/src/auth/auth-service/oauth-ops.ts
+++ b/core/src/auth/auth-service/oauth-ops.ts
@@ -29,6 +29,7 @@ export interface OAuthOpsDeps {
     name?: string;
     avatar_url?: string;
     auth_provider?: string;
+    provider_user_id?: string;
     email_verified?: boolean;
   }) => Promise<AuthUser>;
   updateUser: (
@@ -127,43 +128,90 @@ export class OAuthOps {
         oauthUser = await this.deps.oauthManager.validateToken(provider, token);
       }
 
-      // Check if user exists, create if not
-      let user = await this.deps.getUserByUsername(oauthUser.username);
-      if (!user) {
-        const defaultRole = await this.deps.getDefaultRole();
-        user = await this.deps.createUser({
-          username: oauthUser.username,
-          role: defaultRole,
-          email: oauthUser.email,
-          name: oauthUser.name,
-          avatar_url: oauthUser.avatar_url,
-          auth_provider: provider, // Set the authentication provider
-          email_verified: true, // OAuth emails are considered verified
-        });
-      } else {
-        // Update existing user's information on re-authentication
-        const updateData: Parameters<DatabaseService['updateUser']>[1] = {
-          auth_provider: provider,
-          email_verified: true,
-        };
+      // Match by STABLE PROVIDER IDENTITY, never by username alone:
+      // provider usernames are attacker-choosable (register a victim's
+      // username at the provider → the old code silently linked the local
+      // account and overwrote its email), provider user ids are not.
+      const providerUserId =
+        oauthUser.providerUserId || oauthUser.id
+          ? String(oauthUser.providerUserId || oauthUser.id)
+          : undefined;
 
-        // Update fields that might have changed
-        if (oauthUser.email && oauthUser.email !== user.email) {
-          updateData.email = oauthUser.email;
-        }
-        if (oauthUser.name && oauthUser.name !== user.name) {
-          updateData.name = oauthUser.name;
-        }
-        if (oauthUser.avatar_url && oauthUser.avatar_url !== user.avatar_url) {
-          updateData.avatar_url = oauthUser.avatar_url;
-        }
+      let matchedId: number | undefined = providerUserId
+        ? (await this.deps.db.getUserByProvider(provider, providerUserId))?.id
+        : undefined;
 
-        await this.deps.db.updateUser(user.id, updateData);
+      if (matchedId === undefined) {
+        const byUsername = await this.deps.db.getUserByUsername(
+          oauthUser.username
+        );
+        if (
+          byUsername &&
+          byUsername.auth_provider === provider &&
+          !byUsername.provider_user_id
+        ) {
+          // Legacy adoption: an account this provider created BEFORE
+          // provider_user_id existed — bind the identity below. Anything
+          // else holding this username (a local/password account, another
+          // provider's, or a same-provider account bound to a DIFFERENT
+          // identity) must NOT be linked.
+          matchedId = byUsername.id;
+        } else {
+          // Create a fresh account; de-conflict the username when a
+          // non-linkable account already holds it.
+          let username = oauthUser.username;
+          if (byUsername) {
+            username = `${oauthUser.username}-${provider}`;
+            for (
+              let i = 2;
+              (await this.deps.db.getUserByUsername(username)) && i < 50;
+              i++
+            ) {
+              username = `${oauthUser.username}-${provider}-${i}`;
+            }
+          }
+          const defaultRole = await this.deps.getDefaultRole();
+          const created = await this.deps.createUser({
+            username,
+            role: defaultRole,
+            email: oauthUser.email,
+            name: oauthUser.name,
+            avatar_url: oauthUser.avatar_url,
+            auth_provider: provider, // Set the authentication provider
+            provider_user_id: providerUserId,
+            email_verified: true, // OAuth emails are considered verified
+          });
+          matchedId = created.id;
+        }
+      }
 
-        // Refresh user data
-        const updatedUser = await this.deps.db.getUserById(user.id);
-        if (updatedUser) {
-          user = {
+      // Update the matched account on re-authentication and bind the
+      // provider identity for fresh creates / legacy adoptees.
+      const updateData: Parameters<DatabaseService['updateUser']>[1] = {
+        auth_provider: provider,
+        email_verified: true,
+      };
+      if (providerUserId) {
+        updateData.provider_user_id = providerUserId;
+      }
+      const current = await this.deps.db.getUserById(matchedId);
+      if (oauthUser.email && oauthUser.email !== current?.email) {
+        updateData.email = oauthUser.email;
+      }
+      if (oauthUser.name && oauthUser.name !== current?.name) {
+        updateData.name = oauthUser.name;
+      }
+      if (
+        oauthUser.avatar_url &&
+        oauthUser.avatar_url !== current?.avatar_url
+      ) {
+        updateData.avatar_url = oauthUser.avatar_url;
+      }
+      await this.deps.db.updateUser(matchedId, updateData);
+
+      const updatedUser = await this.deps.db.getUserById(matchedId);
+      const user: AuthUser | null = updatedUser
+        ? {
             id: updatedUser.id,
             username: updatedUser.username,
             role: updatedUser.role,
@@ -179,9 +227,8 @@ export class OAuthOps {
             updated_at: updatedUser.updated_at
               ? new Date(updatedUser.updated_at)
               : undefined,
-          };
-        }
-      }
+          }
+        : null;
 
       // Ensure user is not null
       if (!user) {

--- a/core/src/auth/auth-service/password-ops.ts
+++ b/core/src/auth/auth-service/password-ops.ts
@@ -126,6 +126,20 @@ export class PasswordOps {
     }
   }
 
+  /**
+   * The single password-policy chokepoint. AuthConfigManager's validator
+   * existed but was dead code — 1-character passwords were accepted at
+   * every entry point. Every path that receives a PLAINTEXT password must
+   * run it: change/set enforce it below; registration and the CLI (which
+   * hash before core ever sees the password) call it via AuthService.
+   */
+  validatePasswordPolicy(password: string): {
+    valid: boolean;
+    errors: string[];
+  } {
+    return AuthConfigManager.getInstance().validatePassword(password);
+  }
+
   async changePassword(
     userId: number,
     newPassword: string,
@@ -163,6 +177,15 @@ export class PasswordOps {
         return {
           success: false,
           message: `Users authenticated via ${provider} cannot change passwords. Password management is handled by the external authentication.`,
+        };
+      }
+
+      // Enforce the configured password policy before anything mutates.
+      const policy = this.validatePasswordPolicy(newPassword);
+      if (!policy.valid) {
+        return {
+          success: false,
+          message: `Password does not meet requirements: ${policy.errors.join('; ')}`,
         };
       }
 
@@ -266,6 +289,15 @@ export class PasswordOps {
         return {
           success: false,
           message: `Cannot set password for users authenticated via ${provider}. Password management is handled by the external authentication.`,
+        };
+      }
+
+      // Enforce the configured password policy — admin resets included.
+      const policy = this.validatePasswordPolicy(newPassword);
+      if (!policy.valid) {
+        return {
+          success: false,
+          message: `Password does not meet requirements: ${policy.errors.join('; ')}`,
         };
       }
 

--- a/core/src/auth/auth-service/user-ops.ts
+++ b/core/src/auth/auth-service/user-ops.ts
@@ -52,6 +52,7 @@ export class UserOps {
     name?: string;
     avatar_url?: string;
     auth_provider?: string;
+    provider_user_id?: string;
     email_verified?: boolean;
   }): Promise<AuthUser> {
     // Set default role if not provided
@@ -117,6 +118,13 @@ export class UserOps {
         email: user.email,
         name: user.name,
         avatar_url: user.avatar_url,
+        // auth_provider / email_verified / pending_email were previously
+        // dropped here — AuthUser declares them, so a consumer reading the
+        // provider off getUserById() saw undefined (e.g. an OAuth-takeover
+        // guard would misjudge the account type).
+        auth_provider: user.auth_provider,
+        email_verified: !!user.email_verified,
+        pending_email: user.pending_email,
         created_at: user.created_at ? new Date(user.created_at) : undefined,
         updated_at: user.updated_at ? new Date(user.updated_at) : undefined,
       };

--- a/core/src/auth/role-manager.ts
+++ b/core/src/auth/role-manager.ts
@@ -419,8 +419,23 @@ export class RoleManager {
     return false;
   }
 
-  private getRolePermissions(role: string, config: RolesConfig): string[] {
+  private getRolePermissions(
+    role: string,
+    config: RolesConfig,
+    visited: Set<string> = new Set()
+  ): string[] {
     const permissions = new Set<string>();
+
+    // Cycle guard: a circular role_hierarchy (e.g. admin → clerk → admin)
+    // used to recurse to stack overflow, which userCan then swallowed as
+    // `false` — silently denying EVERY permission with no diagnosable error.
+    if (visited.has(role)) {
+      logger.warn(
+        `[RoleManager] Circular role inheritance detected at '${role}' (chain: ${[...visited].join(' → ')}) — check role_hierarchy in roles.yml`
+      );
+      return [];
+    }
+    visited.add(role);
 
     logger.debug(`[RoleManager] Getting permissions for role: ${role}`);
 
@@ -511,7 +526,8 @@ export class RoleManager {
       for (const inheritedRole of inheritedRoles) {
         const inheritedPermissions = this.getRolePermissions(
           inheritedRole,
-          config
+          config,
+          visited
         );
         inheritedPermissions.forEach((p) => permissions.add(p));
       }

--- a/core/src/database/database-service.ts
+++ b/core/src/database/database-service.ts
@@ -188,6 +188,12 @@ export class DatabaseService {
     return this.users.getUserByEmail(...args);
   }
 
+  async getUserByProvider(
+    ...args: Parameters<UserStore['getUserByProvider']>
+  ): ReturnType<UserStore['getUserByProvider']> {
+    return this.users.getUserByProvider(...args);
+  }
+
   async getUserWithPassword(
     ...args: Parameters<UserStore['getUserWithPassword']>
   ): ReturnType<UserStore['getUserWithPassword']> {

--- a/core/src/database/schema/migrations.ts
+++ b/core/src/database/schema/migrations.ts
@@ -180,6 +180,12 @@ const USER_SECURITY_MIGRATIONS = [
     description: 'Authentication provider tracking',
   },
   {
+    column: 'provider_user_id',
+    sql: 'ALTER TABLE users ADD COLUMN provider_user_id TEXT',
+    description:
+      'Stable OAuth provider identity — account linking must match (auth_provider, provider_user_id), never username',
+  },
+  {
     column: 'email_verified',
     sql: 'ALTER TABLE users ADD COLUMN email_verified BOOLEAN DEFAULT FALSE',
     description: 'Email verification status',
@@ -230,6 +236,21 @@ export async function runUserSecurityMigrations(
     });
   } catch {
     coreDebug('Auth provider update not needed or already completed', {
+      operation: 'database:initialize',
+    });
+  }
+
+  // One provider identity maps to at most one account. Partial index so the
+  // NULLs of local/password users (and legacy OAuth rows awaiting adoption)
+  // don't collide.
+  try {
+    await exec.execute(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_users_provider_identity
+      ON users(auth_provider, provider_user_id)
+      WHERE provider_user_id IS NOT NULL
+    `);
+  } catch {
+    coreDebug('Provider identity index already exists', {
       operation: 'database:initialize',
     });
   }

--- a/core/src/database/schema/tables.ts
+++ b/core/src/database/schema/tables.ts
@@ -15,6 +15,7 @@ export const CORE_TABLE_STATEMENTS: string[] = [
     avatar_url TEXT,
     password_hash TEXT,
     auth_provider TEXT DEFAULT 'password',
+    provider_user_id TEXT,
     email_verified BOOLEAN DEFAULT FALSE,
     pending_email TEXT,
     pending_email_token TEXT,

--- a/core/src/database/stores/user-store.ts
+++ b/core/src/database/stores/user-store.ts
@@ -33,10 +33,11 @@ export class UserStore {
     name?: string;
     avatar_url?: string;
     auth_provider?: string;
+    provider_user_id?: string;
     email_verified?: boolean;
   }): Promise<number> {
     await this.adapter.execute(
-      'INSERT INTO users (username, role, email, name, avatar_url, auth_provider, email_verified) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      'INSERT INTO users (username, role, email, name, avatar_url, auth_provider, provider_user_id, email_verified) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
       [
         userData.username,
         userData.role,
@@ -44,6 +45,7 @@ export class UserStore {
         userData.name,
         userData.avatar_url,
         userData.auth_provider || 'password',
+        userData.provider_user_id ?? null,
         userData.email_verified || false,
       ]
     );
@@ -67,6 +69,22 @@ export class UserStore {
     const rows = await this.adapter.query<UserRow>(
       'SELECT * FROM users WHERE id = ?',
       [id]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  /**
+   * Look up a user by stable OAuth identity. THIS — never username — is how
+   * OAuth logins must match accounts: provider usernames are attacker-
+   * choosable, provider user ids are not.
+   */
+  async getUserByProvider(
+    provider: string,
+    providerUserId: string
+  ): Promise<UserRow | null> {
+    const rows = await this.adapter.query<UserRow>(
+      'SELECT * FROM users WHERE auth_provider = ? AND provider_user_id = ?',
+      [provider, providerUserId]
     );
     return rows.length > 0 ? rows[0] : null;
   }
@@ -143,6 +161,7 @@ export class UserStore {
       passwordHash?: string;
       avatar_url?: string;
       auth_provider?: string;
+      provider_user_id?: string;
       email_verified?: boolean;
       pending_email?: string;
       pending_email_token?: string;
@@ -171,6 +190,10 @@ export class UserStore {
     if (userData.avatar_url !== undefined) {
       updates.push('avatar_url = ?');
       values.push(userData.avatar_url);
+    }
+    if (userData.provider_user_id !== undefined) {
+      updates.push('provider_user_id = ?');
+      values.push(userData.provider_user_id);
     }
     if (userData.auth_provider !== undefined) {
       updates.push('auth_provider = ?');

--- a/core/src/database/types/row-types.ts
+++ b/core/src/database/types/row-types.ts
@@ -44,6 +44,7 @@ export interface UserRow extends SqlRow {
   avatar_url?: string;
   password_hash?: string;
   auth_provider?: string;
+  provider_user_id?: string;
   email_verified?: number;
   pending_email?: string;
   pending_email_token?: string;

--- a/docs/backlog/2026-07-post-audit-hardening.md
+++ b/docs/backlog/2026-07-post-audit-hardening.md
@@ -53,20 +53,20 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` landed+verified · `[-]`
 - [ ] Executable uploads: warning → deny
 - [ ] Realtime: enforce `max_rooms`; set WS `maxPayload`
 
-## Tier C — correctness bugs
+## Tier C — correctness bugs (SCOUTED 2026-07-16, file:line below)
 
-- [ ] Storage streaming: failover/retry/metrics parity, GCS support, streamed size≠0
-- [ ] `updateFile` folder-cache invalidation; failover-on-read returns wrong null
-- [ ] `CIVIC_DATA_DIR` DB-path divergence + dropped `.civicrc`
-- [ ] CLI `login`/`auth:login` never persists token where `resolveToken()` reads
-- [ ] geography `/linked-records` 1000-cap row loss + totals; `/records/:id/raw` missing `optionalAuth`
-- [ ] record-history commit-message-substring filter → pathspec (API + CLI)
-- [ ] publishDraft draft-deletion ordering vs git commit
-- [ ] BB device health-monitor + stale-reaper wired in
+- [ ] Storage streaming (`modules/storage/.../streaming-ops.ts`): GCS missing from the switch (L142-180, throws at L178); stream path bypasses failover/retry/metrics (calls uploadStreamTo* directly, no StorageFailoverManager); S3/Azure streamed `size` persisted as 0 (L164/L176 `request.size||0`, comment "provider will set size" is false → breaks quota)
+- [ ] `updateFile` (`file-mgmt-ops.ts:273-291`) never invalidates folder cache (dead `invalidateFile` at `storage-metadata-cache-adapter.ts:124`); failover-on-read returns `null` as "success" so it never fails over to the provider holding the object (`download-ops.ts` L159/L191/L306 return null; `storage-failover-manager.ts:100` treats resolved null as success)
+- [ ] `CIVIC_DATA_DIR` (`central-config.ts:144-156`): early-return hardcodes sqlite path AND skips the entire `.civicrc` load/merge (drops `auth` + all other config)
+- [ ] CLI login token (`login.ts:163-177` / `auth.ts:80-95`): never writes `~/.civicpress/token` that `resolveToken` reads (`auth-utils.ts:31-38`); human mode never prints the token either
+- [ ] geography `/linked-records` (`geography.ts:448-499`, cap L27) loses rows past 1000 + wrong total/totalPages; `/records/:id/raw` (`read-handlers.ts:374`) missing `optionalAuth` → editors always treated as public
+- [ ] record-history filter: no-op `.replace('/','/')` substring match (`history.ts:103,263`); CLI `civic history` ignores the record arg entirely (`history.ts:70`). Fix = pathspec-scoped `GitEngine.getHistory` (`git-engine.ts:139`)
+- [ ] publishDraft ordering (`publish-draft-saga.ts` steps L552-559): DeleteDraftStep (L402) runs after the irreversible CommitToGitStep (L362, isCompensatable=false) with a log-only no-op compensation (L423) → DB hiccup loses a committed record's draft unrecoverably
+- [ ] BB device health-monitor + stale-reaper implemented (`device-connection-tracker.ts:304`/`335`) but never started in production; wire at the tracker factory (`broadcast-box-services.ts:294-310`)
 - [ ] UI: `useMarkdown` heading inline formatting; autosave timer unmount; editor host collab-vs-CM latch at mount
 - [ ] HW multi-output ffmpeg filtergraph pad reuse (`[v_wm]` mapped twice)
 - [x] `.npmrc:29` jammed keys (folded into CI batch — trailing `strict-peer-dependencies=false` never parsed; dropped it, preserving effective config)
-- [ ] Notifications: empty-recipient dispatch; SMS/Slack phantom config
+- [ ] Notifications: empty recipient dispatched silently (`notification-service.ts:278-292` returns '', no guard in sendToChannel L262); SMS/Slack config declared (`notification-config.ts:51-66`) but only email channel implemented → "Channel not found" throw if enabled
 
 ## Tier D — small, batchable
 

--- a/modules/api/src/routes/config.ts
+++ b/modules/api/src/routes/config.ts
@@ -3,6 +3,7 @@ import { configurationService, CentralConfigManager } from '@civicpress/core';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, dirname } from 'path';
 import { authMiddleware, requirePermission } from '../middleware/auth.js';
+import { logApiError } from '../utils/api-logger.js';
 import { AuditLogger } from '@civicpress/core';
 
 const router = Router();
@@ -22,9 +23,10 @@ router.get('/attachment-types', async (req, res) => {
       data: config,
     });
   } catch (error) {
+    logApiError('config', error, req);
     res.status(500).json({
       success: false,
-      error: `Failed to get attachment types: ${error}`,
+      error: 'Failed to get attachment types',
     });
   }
 });
@@ -42,9 +44,10 @@ router.get('/link-categories', async (req, res) => {
       data: config,
     });
   } catch (error) {
+    logApiError('config', error, req);
     res.status(500).json({
       success: false,
-      error: `Failed to get link categories: ${error}`,
+      error: 'Failed to get link categories',
     });
   }
 });
@@ -117,9 +120,10 @@ router.post(
           message: String(error),
         });
       }
+      logApiError('config', error, req);
       res.status(500).json({
         success: false,
-        error: `Failed to validate configuration: ${error}`,
+        error: 'Failed to validate configuration',
       });
     }
   }
@@ -145,9 +149,10 @@ router.get('/list', async (req, res) => {
       data: configs,
     });
   } catch (error) {
+    logApiError('config', error, req);
     res.status(500).json({
       success: false,
-      error: `Failed to get configuration list: ${error}`,
+      error: 'Failed to get configuration list',
     });
   }
 });
@@ -166,9 +171,10 @@ router.get('/metadata/:type', async (req, res) => {
       data: metadata,
     });
   } catch (error) {
+    logApiError('config', error, req);
     res.status(404).json({
       success: false,
-      error: `Configuration metadata not found: ${error}`,
+      error: 'Configuration metadata not found',
     });
   }
 });
@@ -220,9 +226,10 @@ router.get('/raw/:type', async (req, res) => {
     if (error instanceof InvalidConfigTypeError) {
       return res.status(400).json({ success: false, error: error.message });
     }
+    logApiError('config', error, req);
     res.status(404).json({
       success: false,
-      error: `Raw configuration not found: ${error}`,
+      error: 'Raw configuration not found',
     });
   }
 });
@@ -276,9 +283,10 @@ router.put(
       if (error instanceof InvalidConfigTypeError) {
         return res.status(400).json({ success: false, error: error.message });
       }
+      logApiError('config', error, req);
       res.status(500).json({
         success: false,
-        error: `Failed to save raw configuration: ${error}`,
+        error: 'Failed to save raw configuration',
       });
     }
   }
@@ -296,9 +304,10 @@ router.get('/status', async (req, res) => {
       data: status,
     });
   } catch (error) {
+    logApiError('config', error, req);
     res.status(500).json({
       success: false,
-      error: `Failed to get configuration status: ${error}`,
+      error: 'Failed to get configuration status',
     });
   }
 });
@@ -317,9 +326,10 @@ router.get('/:type', async (req, res) => {
       data: config,
     });
   } catch (error) {
+    logApiError('config', error, req);
     res.status(404).json({
       success: false,
-      error: `Configuration not found: ${error}`,
+      error: 'Configuration not found',
     });
   }
 });
@@ -359,9 +369,10 @@ router.put('/:type', async (req, res) => {
       outcome: 'failure',
       message: String(error),
     });
+    logApiError('config', error, req);
     res.status(500).json({
       success: false,
-      error: `Failed to save configuration: ${error}`,
+      error: 'Failed to save configuration',
     });
   }
 });
@@ -400,9 +411,10 @@ router.post('/:type/reset', async (req, res) => {
       outcome: 'failure',
       message: String(error),
     });
+    logApiError('config', error, req);
     res.status(500).json({
       success: false,
-      error: `Failed to reset configuration: ${error}`,
+      error: 'Failed to reset configuration',
     });
   }
 });
@@ -427,9 +439,10 @@ router.get('/validate/all', async (req, res) => {
       try {
         results[type] = await configurationService.validateConfiguration(type);
       } catch (error) {
+        logApiError('config', error, req);
         results[type] = {
           valid: false,
-          errors: [`Failed to validate: ${error}`],
+          errors: ['Failed to validate'],
         };
       }
     }
@@ -439,9 +452,10 @@ router.get('/validate/all', async (req, res) => {
       data: results,
     });
   } catch (error) {
+    logApiError('config', error, req);
     res.status(500).json({
       success: false,
-      error: `Failed to validate configurations: ${error}`,
+      error: 'Failed to validate configurations',
     });
   }
 });

--- a/modules/api/src/routes/info.ts
+++ b/modules/api/src/routes/info.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { CentralConfigManager } from '@civicpress/core';
 import type { AuthUser } from '@civicpress/core';
+import { logApiError } from '../utils/api-logger.js';
 
 const router = Router();
 
@@ -95,9 +96,12 @@ router.get('/', async (req, res) => {
 
     res.json(response);
   } catch (error) {
+    // Unauthenticated endpoint — never surface the raw message (this route
+    // reads YAML config, so errors can carry filesystem paths).
+    logApiError('info', error, req);
     res.status(500).json({
       success: false,
-      error: error instanceof Error ? error.message : 'Unknown error',
+      error: 'Failed to load system info',
     });
   }
 });

--- a/modules/api/src/routes/notifications.ts
+++ b/modules/api/src/routes/notifications.ts
@@ -164,9 +164,11 @@ router.post('/test', async (req, res) => {
       outcome: 'failure',
       message: errorMessage,
     });
+    // The raw message stays in the audit log above — never on the wire
+    // (SMTP errors carry hosts, credential hints, and config paths).
     return res.status(500).json({
       success: false,
-      error: errorMessage || 'Failed to send test email',
+      error: 'Failed to send test email',
     });
   }
 });

--- a/modules/api/src/routes/system.ts
+++ b/modules/api/src/routes/system.ts
@@ -4,6 +4,7 @@ import {
   getRecordTypesWithMetadata,
   getRecordStatusesWithMetadata,
 } from '@civicpress/core';
+import { logApiError } from '../utils/api-logger.js';
 
 const router = Router();
 
@@ -36,12 +37,12 @@ router.get('/record-types', (req, res) => {
       },
     });
   } catch (error) {
+    logApiError('system:record-types', error, req);
     res.status(500).json({
       success: false,
       error: {
         message: 'Failed to fetch record types',
         code: 'RECORD_TYPES_FETCH_FAILED',
-        details: error instanceof Error ? error.message : String(error),
       },
     });
   }
@@ -79,12 +80,12 @@ router.get('/record-statuses', (req, res) => {
       },
     });
   } catch (error) {
+    logApiError('system:record-statuses', error, req);
     res.status(500).json({
       success: false,
       error: {
         message: 'Failed to fetch record statuses',
         code: 'RECORD_STATUSES_FETCH_FAILED',
-        details: error instanceof Error ? error.message : String(error),
       },
     });
   }

--- a/modules/api/src/routes/users/auxiliary-handlers.ts
+++ b/modules/api/src/routes/users/auxiliary-handlers.ts
@@ -67,6 +67,18 @@ export function registerRegistrationRoutes(router: Router): void {
 
       const authService = civicPress.getAuthService();
 
+      // Enforce the configured password policy — registration hashes the
+      // plaintext below, so this is its only chance to be checked.
+      const policy = authService.validatePasswordPolicy(userData.password);
+      if (!policy.valid) {
+        const error = new HttpError(
+          400,
+          `Password does not meet requirements: ${policy.errors.join('; ')}`,
+          'WEAK_PASSWORD'
+        );
+        return handleApiError('register_user', error, req, res);
+      }
+
       // Normalize email (lowercase) for consistency
       const normalizedEmail = userData.email.toLowerCase().trim();
 

--- a/modules/api/src/routes/users/crud-handlers.ts
+++ b/modules/api/src/routes/users/crud-handlers.ts
@@ -141,6 +141,17 @@ export function registerCrudRoutes(router: Router): void {
       // Hash password if provided
       let passwordHash: string | undefined;
       if (userData.password) {
+        // Enforce the password policy — this admin create route hashes
+        // inline, so it must run the check itself (like register + CLI).
+        const policy = authService.validatePasswordPolicy(userData.password);
+        if (!policy.valid) {
+          const error = new HttpError(
+            400,
+            `Password does not meet requirements: ${policy.errors.join('; ')}`,
+            'WEAK_PASSWORD'
+          );
+          return handleApiError('create_user', error, req, res);
+        }
         const bcrypt = await import('bcrypt');
         const saltRounds = 12;
         passwordHash = await bcrypt.hash(userData.password, saltRounds);
@@ -383,6 +394,19 @@ export function registerCrudRoutes(router: Router): void {
           const error = new HttpError(400, 
             `Users authenticated via ${provider} cannot set passwords. Password management is handled by the external provider.`
           , 'EXTERNAL_AUTH_PASSWORD_FORBIDDEN');
+          return handleApiError('update_user', error, req, res);
+        }
+
+        // Enforce the password policy — this admin update route hashes
+        // inline (unlike POST /:id/set-password, which goes through
+        // PasswordOps), so it must run the check itself.
+        const policy = authService.validatePasswordPolicy(userData.password);
+        if (!policy.valid) {
+          const error = new HttpError(
+            400,
+            `Password does not meet requirements: ${policy.errors.join('; ')}`,
+            'WEAK_PASSWORD'
+          );
           return handleApiError('update_user', error, req, res);
         }
 

--- a/modules/api/src/utils/api-logger.ts
+++ b/modules/api/src/utils/api-logger.ts
@@ -301,12 +301,20 @@ export class ApiLogger {
       };
     }
 
+    // Unexpected error: never leak the raw message to the client — it can
+    // carry paths, SQL fragments, or config values. Full detail stays in the
+    // server-side log (handleError logs before responding); clients get it
+    // only in development.
     return {
       statusCode: 500,
       success: false,
       error: {
         message: defaultMessage,
-        details: error instanceof Error ? error.message : 'Unknown error',
+        ...(process.env.NODE_ENV === 'development'
+          ? {
+              details: error instanceof Error ? error.message : String(error),
+            }
+          : {}),
       },
     };
   }

--- a/modules/api/src/utils/api-logger.ts
+++ b/modules/api/src/utils/api-logger.ts
@@ -291,11 +291,19 @@ export class ApiLogger {
         statusCode?: number;
         code?: string;
       };
+      const statusCode = legacy.statusCode ?? 500;
+      // A 5xx from an untyped third-party error (AWS SDK, HTTP clients) can
+      // carry hosts/paths — redact its message like the generic-500 branch.
+      // 4xx messages are caller-facing and safe to pass through.
+      const isServerError = statusCode >= 500;
       return {
-        statusCode: legacy.statusCode ?? 500,
+        statusCode,
         success: false,
         error: {
-          message: error.message,
+          message:
+            isServerError && process.env.NODE_ENV !== 'development'
+              ? defaultMessage
+              : error.message,
           code: legacy.code ?? 'API_ERROR',
         },
       };

--- a/modules/realtime/src/realtime-server.ts
+++ b/modules/realtime/src/realtime-server.ts
@@ -290,6 +290,10 @@ export class RealtimeServer {
       this.server = new WebSocketServer({
         port: this.realtimeConfig.port,
         host: this.realtimeConfig.host,
+        // Cap per-message size — the ws default (~100 MiB) is a one-message
+        // memory-DoS surface. 10 MiB comfortably covers Yjs document
+        // updates while bounding the damage.
+        maxPayload: 10 * 1024 * 1024,
         // Use verifyClient to ensure path starts with /realtime
         verifyClient: (info: {
           origin: string;
@@ -703,6 +707,19 @@ export class RealtimeServer {
 
     if (!this.roomManager) {
       throw new Error('Room manager not initialized');
+    }
+
+    // Enforce rooms.max_rooms — previously only reported in health metrics
+    // while room creation stayed unbounded (memory DoS via unique room ids).
+    // Joining an EXISTING room is always allowed at the cap.
+    const maxRooms = this.realtimeConfig?.rooms.max_rooms || 100;
+    if (
+      !this.roomManager.getRoom(fullRoomId) &&
+      this.roomManager.getRoomCount() >= maxRooms
+    ) {
+      throw new Error(
+        `Room limit reached (${maxRooms}); cannot create room ${fullRoomId}`
+      );
     }
 
     room = this.roomManager.getOrCreateRoom(fullRoomId, roomInfo.roomType, {});

--- a/modules/storage/src/cloud-uuid-storage/validation.ts
+++ b/modules/storage/src/cloud-uuid-storage/validation.ts
@@ -58,9 +58,12 @@ export class StorageValidation {
       );
     }
 
-    // Check for suspicious file types
+    // Executable types are DENIED outright — a warning that nobody reads
+    // while the upload proceeds is not a control (post-audit hardening).
     if (['exe', 'bat', 'cmd', 'sh', 'ps1'].includes(fileExtension)) {
-      warnings.push(`Executable file type '${fileExtension}' detected`);
+      errors.push(
+        `Executable file type '${fileExtension}' is not allowed for upload`
+      );
     }
 
     return {

--- a/modules/storage/src/cloud-uuid-storage/validation.ts
+++ b/modules/storage/src/cloud-uuid-storage/validation.ts
@@ -58,9 +58,21 @@ export class StorageValidation {
       );
     }
 
-    // Executable types are DENIED outright — a warning that nobody reads
-    // while the upload proceeds is not a control (post-audit hardening).
-    if (['exe', 'bat', 'cmd', 'sh', 'ps1'].includes(fileExtension)) {
+    // Executable / installer / script types are DENIED outright — a warning
+    // that nobody reads while the upload proceeds is not a control
+    // (post-audit hardening). This is an extension deny-list, not a full
+    // content sniff, but it covers the common executable set across
+    // Windows / *nix / cross-platform runtimes.
+    const EXECUTABLE_EXTENSIONS = new Set([
+      // Windows
+      'exe', 'bat', 'cmd', 'com', 'scr', 'msi', 'dll', 'cpl', 'vbs', 'vbe',
+      'js', 'jse', 'wsf', 'wsh', 'ps1', 'psm1', 'reg', 'lnk',
+      // *nix / shells
+      'sh', 'bash', 'zsh', 'ksh', 'csh', 'run', 'bin', 'elf',
+      // cross-platform runtimes / installers
+      'jar', 'app', 'deb', 'rpm', 'dmg', 'pkg', 'apk',
+    ]);
+    if (EXECUTABLE_EXTENSIONS.has(fileExtension)) {
       errors.push(
         `Executable file type '${fileExtension}' is not allowed for upload`
       );

--- a/modules/storage/src/cloud-uuid-storage/validation.ts
+++ b/modules/storage/src/cloud-uuid-storage/validation.ts
@@ -63,14 +63,18 @@ export class StorageValidation {
     // (post-audit hardening). This is an extension deny-list, not a full
     // content sniff, but it covers the common executable set across
     // Windows / *nix / cross-platform runtimes.
+    // Unambiguous executable / installer / script extensions only. Ambiguous
+    // ones (e.g. .bin firmware blobs, .app bundles-as-dirs) are deliberately
+    // omitted — this is a deny-list of things that are executable by nature,
+    // not a data-file blocker.
     const EXECUTABLE_EXTENSIONS = new Set([
       // Windows
-      'exe', 'bat', 'cmd', 'com', 'scr', 'msi', 'dll', 'cpl', 'vbs', 'vbe',
-      'js', 'jse', 'wsf', 'wsh', 'ps1', 'psm1', 'reg', 'lnk',
+      'exe', 'bat', 'cmd', 'com', 'scr', 'msi', 'cpl', 'vbs', 'vbe',
+      'jse', 'wsf', 'wsh', 'ps1', 'psm1', 'reg',
       // *nix / shells
-      'sh', 'bash', 'zsh', 'ksh', 'csh', 'run', 'bin', 'elf',
+      'sh', 'bash', 'zsh', 'ksh', 'csh',
       // cross-platform runtimes / installers
-      'jar', 'app', 'deb', 'rpm', 'dmg', 'pkg', 'apk',
+      'jar', 'deb', 'rpm', 'apk',
     ]);
     if (EXECUTABLE_EXTENSIONS.has(fileExtension)) {
       errors.push(

--- a/modules/ui/app/stores/auth.ts
+++ b/modules/ui/app/stores/auth.ts
@@ -267,32 +267,11 @@ export const useAuthStore = defineStore('auth', {
       }
     },
 
-    // Development method to set mock user
-    setMockUser() {
-      const mockUser: User = {
-        id: 1,
-        username: 'admin',
-        email: 'admin@example.com',
-        name: 'Admin User',
-        role: 'admin',
-        permissions: [
-          'records:create',
-          'records:edit',
-          'records:delete',
-          'records:view',
-        ],
-      };
-
-      this.user = mockUser;
-      this.isAuthenticated = true;
-      this.token = 'mock-token';
-      this.sessionExpiresAt = new Date(
-        Date.now() + 24 * 60 * 60 * 1000
-      ).toISOString();
-      this.saveAuthState();
-
-      console.log('Mock user set:', mockUser);
-    },
+    // NOTE: the old setMockUser() dev helper was deleted (post-audit
+    // hardening): it shipped in the production bundle as a zero-caller
+    // console-invocable action that flipped the store to an admin user.
+    // Client state is not a security boundary — the API re-authorizes every
+    // request — but a one-call admin-UI escalation is not something to ship.
 
     // Validate token and refresh user data
     async validateToken() {

--- a/tests/api/password-policy-routes.test.ts
+++ b/tests/api/password-policy-routes.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import {
+  createAPITestContext,
+  cleanupAPITestContext,
+  APITestContext,
+} from '../fixtures/test-setup';
+
+/**
+ * Post-audit hardening batch 3 (skeptic follow-up): the password policy must
+ * hold on EVERY route that sets a password, not just registration. The
+ * adversarial pass proved the admin create (POST /api/v1/users) and update
+ * (PUT /api/v1/users/:id) routes hashed inline and bypassed the policy — a
+ * working admin with a 1-char password. These lock that shut.
+ */
+describe('Password policy on admin user routes', () => {
+  let context: APITestContext;
+  let adminToken: string;
+
+  beforeEach(async () => {
+    context = await createAPITestContext();
+    const adminResponse = await request(context.api.getApp())
+      .post('/api/v1/auth/simulated')
+      .send({ username: 'admin', role: 'admin' });
+    adminToken = adminResponse.body.data.session.token;
+  });
+
+  afterEach(async () => {
+    await cleanupAPITestContext(context);
+  });
+
+  it('POST /api/v1/users rejects a weak password', async () => {
+    const res = await request(context.api.getApp())
+      .post('/api/v1/users')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        username: 'weakadmin',
+        email: 'weakadmin@example.com',
+        password: 'x',
+        role: 'admin',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error?.code).toBe('WEAK_PASSWORD');
+  });
+
+  it('POST /api/v1/users accepts a compliant password', async () => {
+    const res = await request(context.api.getApp())
+      .post('/api/v1/users')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        username: 'strongadmin',
+        email: 'strongadmin@example.com',
+        password: 'Str0ng!Passw0rd',
+        role: 'public',
+      });
+    expect([200, 201]).toContain(res.status);
+  });
+
+  it('PUT /api/v1/users/:id rejects a weak password', async () => {
+    const created = await request(context.api.getApp())
+      .post('/api/v1/users')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        username: 'updatable',
+        email: 'updatable@example.com',
+        password: 'Str0ng!Passw0rd',
+        role: 'public',
+      });
+    const id = created.body.data?.user?.id ?? created.body.data?.id;
+    expect(id).toBeDefined();
+
+    const res = await request(context.api.getApp())
+      .put(`/api/v1/users/${id}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ password: 'y' });
+    expect(res.status).toBe(400);
+    expect(res.body.error?.code).toBe('WEAK_PASSWORD');
+  });
+});

--- a/tests/api/security-features.test.ts
+++ b/tests/api/security-features.test.ts
@@ -30,7 +30,7 @@ describe('API Security Features', () => {
         .send({
           username: 'passworduser',
           email: 'password@example.com',
-          password: 'currentpass123',
+          password: 'Currentpass!123',
           name: 'Password User',
         });
       passwordUserId = passwordUserResponse.body.data.user.id;
@@ -68,8 +68,8 @@ describe('API Security Features', () => {
           .post(`/api/v1/users/${simulatedUserId}/change-password`)
           .set('Authorization', `Bearer ${userToken}`)
           .send({
-            currentPassword: 'currentpass123',
-            newPassword: 'newpass123',
+            currentPassword: 'Currentpass!123',
+            newPassword: 'Newpass!123',
           });
 
         // Note: This will fail because simulated auth doesn't have actual password
@@ -91,7 +91,7 @@ describe('API Security Features', () => {
           .set('Authorization', `Bearer ${adminToken}`)
           .send({
             currentPassword: 'anypassword',
-            newPassword: 'newpass123',
+            newPassword: 'Newpass!123',
           });
 
         expect(response.status).toBe(403);
@@ -104,8 +104,8 @@ describe('API Security Features', () => {
         const response = await request(context.api.getApp())
           .post(`/api/v1/users/${passwordUserId}/change-password`)
           .send({
-            currentPassword: 'currentpass123',
-            newPassword: 'newpass123',
+            currentPassword: 'Currentpass!123',
+            newPassword: 'Newpass!123',
           });
 
         expect(response.status).toBe(401);
@@ -136,7 +136,7 @@ describe('API Security Features', () => {
           .post(`/api/v1/users/${passwordUserId}/set-password`)
           .set('Authorization', `Bearer ${adminToken}`)
           .send({
-            password: 'adminsetpass123',
+            password: 'Adminsetpass!123',
           });
 
         expect(response.status).toBe(200);
@@ -151,7 +151,7 @@ describe('API Security Features', () => {
           .post(`/api/v1/users/${githubUserId}/set-password`)
           .set('Authorization', `Bearer ${adminToken}`)
           .send({
-            password: 'adminsetpass123',
+            password: 'Adminsetpass!123',
           });
 
         expect(response.status).toBe(403);
@@ -172,7 +172,7 @@ describe('API Security Features', () => {
           .post(`/api/v1/users/${passwordUserId}/set-password`)
           .set('Authorization', `Bearer ${userToken}`)
           .send({
-            password: 'usersetpass123',
+            password: 'Usersetpass!123',
           });
 
         expect(response.status).toBe(403);
@@ -186,7 +186,7 @@ describe('API Security Features', () => {
           .post('/api/v1/users/99999/set-password')
           .set('Authorization', `Bearer ${adminToken}`)
           .send({
-            password: 'adminsetpass123',
+            password: 'Adminsetpass!123',
           });
 
         expect(response.status).toBe(404);
@@ -206,7 +206,7 @@ describe('API Security Features', () => {
         .send({
           username: 'emailtestuser',
           email: 'emailtest@example.com',
-          password: 'password123',
+          password: 'Passw0rd!123',
           name: 'Email Test User',
         });
       testUserId = userResponse.body.data.user.id;
@@ -260,7 +260,7 @@ describe('API Security Features', () => {
           .send({
             username: 'existinguser',
             email: 'existing@example.com',
-            password: 'password123',
+            password: 'Passw0rd!123',
             name: 'Existing User',
           });
 
@@ -294,7 +294,7 @@ describe('API Security Features', () => {
           .send({
             username: 'otheruser',
             email: 'other@example.com',
-            password: 'password123',
+            password: 'Passw0rd!123',
             name: 'Other User',
           });
         const otherUserId = otherUserResponse.body.data.user.id;
@@ -457,7 +457,7 @@ describe('API Security Features', () => {
           .send({
             username: 'securityother',
             email: 'securityother@example.com',
-            password: 'password123',
+            password: 'Passw0rd!123',
             name: 'Security Other User',
           });
         const otherUserId = otherUserResponse.body.data.user.id;
@@ -494,7 +494,7 @@ describe('API Security Features', () => {
         .send({
           username: 'updatepassworduser',
           email: 'updatepassword@example.com',
-          password: 'password123',
+          password: 'Passw0rd!123',
           name: 'Update Password User',
         });
       passwordUserId = passwordUserResponse.body.data.user.id;
@@ -539,7 +539,7 @@ describe('API Security Features', () => {
           .set('Authorization', `Bearer ${adminToken}`)
           .send({
             name: 'Updated GitHub User',
-            password: 'newpassword123',
+            password: 'Newpassword!123',
           });
 
         expect(response.status).toBe(403);
@@ -554,7 +554,7 @@ describe('API Security Features', () => {
           .set('Authorization', `Bearer ${adminToken}`)
           .send({
             name: 'Updated Password User',
-            password: 'newpassword123',
+            password: 'Newpassword!123',
           });
 
         expect(response.status).toBe(200);

--- a/tests/api/users.test.ts
+++ b/tests/api/users.test.ts
@@ -23,7 +23,7 @@ describe('API User Management', () => {
       const userData = {
         username: 'newuser',
         email: 'newuser@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'New User',
       };
 
@@ -43,7 +43,7 @@ describe('API User Management', () => {
     it('should fail registration with missing username', async () => {
       const userData = {
         email: 'test@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Test User',
       };
 
@@ -75,7 +75,7 @@ describe('API User Management', () => {
     it('should fail registration with missing email', async () => {
       const userData = {
         username: 'testuser',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Test User',
       };
 
@@ -92,14 +92,14 @@ describe('API User Management', () => {
       const userData1 = {
         username: 'duplicateuser',
         email: 'duplicate1@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'First User',
       };
 
       const userData2 = {
         username: 'duplicateuser', // Same username
         email: 'duplicate2@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Second User',
       };
 
@@ -133,7 +133,7 @@ describe('API User Management', () => {
         const userData = {
           username: `testuser_${Date.now()}_${Math.random()}`,
           email: email,
-          password: 'password123',
+          password: 'Passw0rd!123',
           name: 'Test User',
         };
 
@@ -152,14 +152,14 @@ describe('API User Management', () => {
       const userData1 = {
         username: 'user1',
         email: 'duplicate@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'First User',
       };
 
       const userData2 = {
         username: 'user2', // Different username
         email: 'duplicate@example.com', // Same email
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Second User',
       };
 
@@ -185,7 +185,7 @@ describe('API User Management', () => {
       const userData = {
         username: 'emailtest',
         email: 'TestUser@Example.COM', // Mixed case email
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Test User',
       };
 
@@ -203,7 +203,7 @@ describe('API User Management', () => {
       const userData = {
         username: 'roleattempt',
         email: 'roleattempt@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Role Attempt',
         role: 'admin', // Attempt to set admin role
       };
@@ -223,14 +223,14 @@ describe('API User Management', () => {
       const userData1 = {
         username: 'caseuser1',
         email: 'CaseTest@Example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'First User',
       };
 
       const userData2 = {
         username: 'caseuser2',
         email: 'casetest@example.com', // Same email, different case
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Second User',
       };
 
@@ -260,7 +260,7 @@ describe('API User Management', () => {
       const userData = {
         username: 'authuser',
         email: 'authuser@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Auth User',
       };
 
@@ -271,7 +271,7 @@ describe('API User Management', () => {
       // Then authenticate
       const authData = {
         username: 'authuser',
-        password: 'password123',
+        password: 'Passw0rd!123',
       };
 
       const response = await request(context.api.getApp())
@@ -290,7 +290,7 @@ describe('API User Management', () => {
       const userData = {
         username: 'wrongpassuser',
         email: 'wrongpass@example.com',
-        password: 'password123',
+        password: 'Passw0rd!123',
         name: 'Wrong Pass User',
       };
 
@@ -315,7 +315,7 @@ describe('API User Management', () => {
     it('should fail authentication with non-existent user', async () => {
       const authData = {
         username: 'nonexistent',
-        password: 'password123',
+        password: 'Passw0rd!123',
       };
 
       const response = await request(context.api.getApp())

--- a/tests/cli/security-commands.test.ts
+++ b/tests/cli/security-commands.test.ts
@@ -127,7 +127,7 @@ describe('CLI Security Commands', () => {
       }
 
       const result = runCLI(
-        `${context.cliPath} users:change-password clipassworduser --new-password "newpass123"`
+        `${context.cliPath} users:change-password clipassworduser --new-password "Newpass!123"`
       );
 
       expect(result.status).toBe(1);
@@ -145,7 +145,7 @@ describe('CLI Security Commands', () => {
       }
 
       const result = runCLI(
-        `${context.cliPath} users:change-password cligithubuser --token "${adminToken}" --current-password "any" --new-password "newpass123"`
+        `${context.cliPath} users:change-password cligithubuser --token "${adminToken}" --current-password "any" --new-password "Newpass!123"`
       );
 
       expect(result.status).toBe(1);
@@ -179,7 +179,7 @@ describe('CLI Security Commands', () => {
       }
 
       const result = runCLI(
-        `${context.cliPath} users:change-password cligithubuser --token "${adminToken}" --current-password "any" --new-password "newpass123" --json`
+        `${context.cliPath} users:change-password cligithubuser --token "${adminToken}" --current-password "any" --new-password "Newpass!123" --json`
       );
 
       expect(result.status).toBe(1);
@@ -207,7 +207,7 @@ describe('CLI Security Commands', () => {
 
       // Create a non-admin token (simulated)
       const result = runCLI(
-        `${context.cliPath} users:set-password clipassworduser --token "fake-user-token" --password "newpass123"`
+        `${context.cliPath} users:set-password clipassworduser --token "fake-user-token" --password "Newpass!123"`
       );
 
       expect(result.status).toBe(1);
@@ -225,7 +225,7 @@ describe('CLI Security Commands', () => {
       }
 
       const result = runCLI(
-        `${context.cliPath} users:set-password cligithubuser --token "${adminToken}" --password "newpass123"`
+        `${context.cliPath} users:set-password cligithubuser --token "${adminToken}" --password "Newpass!123"`
       );
 
       expect(result.status).toBe(1);
@@ -244,7 +244,7 @@ describe('CLI Security Commands', () => {
       }
 
       const result = runCLI(
-        `${context.cliPath} users:set-password clipassworduser --token "${adminToken}" --password "adminsetpass123"`
+        `${context.cliPath} users:set-password clipassworduser --token "${adminToken}" --password "Adminsetpass!123"`
       );
 
       // Check if command succeeded or failed with expected error
@@ -597,7 +597,7 @@ describe('CLI Security Commands', () => {
       }
 
       const result = runCLI(
-        `${context.cliPath} users:create --token "${adminToken}" --username "newsecureuser" --email "newsecure@example.com" --password "securepass123" --name "New Secure User"`
+        `${context.cliPath} users:create --token "${adminToken}" --username "newsecureuser" --email "newsecure@example.com" --password "Securepass!123" --name "New Secure User"`
       );
 
       expect(result.status).toBe(0);
@@ -626,7 +626,7 @@ describe('CLI Security Commands', () => {
       }
 
       const result = runCLI(
-        `${context.cliPath} users:update --token "${adminToken}" --username "cligithubuser" --password "newpass123"`
+        `${context.cliPath} users:update --token "${adminToken}" --username "cligithubuser" --password "Newpass!123"`
       );
 
       expect(result.status).toBe(1);

--- a/tests/cli/users.test.ts
+++ b/tests/cli/users.test.ts
@@ -67,7 +67,7 @@ describe('CLI User Management', () => {
       }
 
       const result = execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testuser1 --password testpass123 --name "Test User 1" --role public --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testuser1 --password Testpass!123 --name "Test User 1" --role public --token ${adminToken}`,
         { encoding: 'utf8' }
       );
 
@@ -82,7 +82,7 @@ describe('CLI User Management', () => {
       }
 
       const result = execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testuser2 --password testpass123 --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testuser2 --password Testpass!123 --token ${adminToken}`,
         { encoding: 'utf8' }
       );
 
@@ -98,7 +98,7 @@ describe('CLI User Management', () => {
 
       expect(() => {
         execSync(
-          `cd ${context.testDir} && node ${context.cliPath} users:create --password testpass123 --token ${adminToken}`,
+          `cd ${context.testDir} && node ${context.cliPath} users:create --password Testpass!123 --token ${adminToken}`,
           { encoding: 'utf8' }
         );
       }).toThrow();
@@ -125,7 +125,7 @@ describe('CLI User Management', () => {
       }
 
       const result = execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testuser4 --password testpass123 --name "Test User 4" --json --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testuser4 --password Testpass!123 --name "Test User 4" --json --token ${adminToken}`,
         { encoding: 'utf8' }
       );
 
@@ -144,7 +144,7 @@ describe('CLI User Management', () => {
       }
 
       execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password regularpass123 --name "Test Regular" --role public --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password Regularpass!123 --name "Test Regular" --role public --token ${adminToken}`,
         { stdio: 'pipe' }
       );
     });
@@ -172,7 +172,7 @@ describe('CLI User Management', () => {
       }
 
       const result = execSync(
-        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password regularpass123 --json`,
+        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password Regularpass!123 --json`,
         { encoding: 'utf8' }
       );
 
@@ -206,7 +206,7 @@ describe('CLI User Management', () => {
 
       expect(() => {
         execSync(
-          `cd ${context.testDir} && node ${context.cliPath} auth:password --username nonexistent --password testpass123`,
+          `cd ${context.testDir} && node ${context.cliPath} auth:password --username nonexistent --password Testpass!123`,
           { stdio: 'pipe' }
         );
       }).toThrow();
@@ -222,13 +222,13 @@ describe('CLI User Management', () => {
       }
 
       execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password regularpass123 --name "Test Regular" --role public --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password Regularpass!123 --name "Test Regular" --role public --token ${adminToken}`,
         { stdio: 'pipe' }
       );
 
       // Get regular user token
       const regularResult = execSync(
-        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password regularpass123 --json`,
+        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password Regularpass!123 --json`,
         { encoding: 'utf8' }
       );
       const regularJsonResult = extractJSONFromOutput(regularResult);
@@ -303,13 +303,13 @@ describe('CLI User Management', () => {
       }
 
       execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password regularpass123 --name "Test Regular" --role public --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password Regularpass!123 --name "Test Regular" --role public --token ${adminToken}`,
         { stdio: 'pipe' }
       );
 
       // Get regular user token
       const regularResult = execSync(
-        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password regularpass123 --json`,
+        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password Regularpass!123 --json`,
         { encoding: 'utf8' }
       );
       const regularJsonResult = extractJSONFromOutput(regularResult);
@@ -373,17 +373,17 @@ describe('CLI User Management', () => {
       }
 
       execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password regularpass123 --name "Test Regular" --role public --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testregular --password Regularpass!123 --name "Test Regular" --role public --token ${adminToken}`,
         { stdio: 'pipe' }
       );
       execSync(
-        `cd ${context.testDir} && node ${context.cliPath} users:create --username testdelete --password deletepass123 --name "Test Delete" --role public --token ${adminToken}`,
+        `cd ${context.testDir} && node ${context.cliPath} users:create --username testdelete --password Deletepass!123 --name "Test Delete" --role public --token ${adminToken}`,
         { stdio: 'pipe' }
       );
 
       // Get regular user token
       const regularResult = execSync(
-        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password regularpass123 --json`,
+        `cd ${context.testDir} && node ${context.cliPath} auth:password --username testregular --password Regularpass!123 --json`,
         { encoding: 'utf8' }
       );
       const regularJsonResult = extractJSONFromOutput(regularResult);

--- a/tests/core/oauth-linking.test.ts
+++ b/tests/core/oauth-linking.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import bcrypt from 'bcrypt';
+import { CivicPress } from '../../core/src/civic-core.js';
+import { AuthService } from '../../core/src/auth/auth-service.js';
+import {
+  createTestDirectory,
+  createRolesConfig,
+  cleanupTestDirectory,
+} from '../fixtures/test-setup';
+
+/**
+ * Post-audit hardening batch 3: OAuth account linking must match by stable
+ * provider identity (auth_provider, provider_user_id) — never by username.
+ * The old code linked any existing account whose username matched the
+ * provider-supplied one and overwrote its email: register a victim's
+ * username at the provider → take over their local account.
+ */
+describe('OAuth account linking by provider identity', () => {
+  let civicPress: CivicPress;
+  let authService: AuthService;
+  let testConfig: ReturnType<typeof createTestDirectory>;
+
+  const oauth = (over: Partial<Record<string, string>> = {}) => ({
+    id: over.id ?? 'gh-1001',
+    username: over.username ?? 'alice',
+    email: over.email ?? 'alice@provider.example',
+    name: over.name ?? 'Alice',
+    provider: 'github',
+    providerUserId: over.providerUserId ?? over.id ?? 'gh-1001',
+  });
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    testConfig = createTestDirectory('oauth-linking-test');
+    createRolesConfig(testConfig);
+    civicPress = new CivicPress({
+      dataDir: testConfig.dataDir,
+      database: {
+        type: 'sqlite',
+        sqlite: { file: join(testConfig.testDir, 'test.db') },
+      },
+    });
+    await civicPress.initialize();
+    authService = civicPress.getAuthService();
+  });
+
+  afterEach(async () => {
+    if (civicPress) {
+      await civicPress.shutdown();
+    }
+    cleanupTestDirectory(testConfig);
+  });
+
+  it('does NOT take over a local password account with the same username', async () => {
+    const local = await authService.createUserWithPassword({
+      username: 'alice',
+      passwordHash: await bcrypt.hash('Local-Passw0rd!1', 12),
+      email: 'alice@town.example',
+      role: 'clerk',
+    });
+
+    const result = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth()
+    );
+
+    // A NEW account is created under a de-conflicted username…
+    expect(result.user.id).not.toBe(local.id);
+    expect(result.user.username).toBe('alice-github');
+    // …and the local account is untouched: email, role, provider intact.
+    const localAfter = await authService.getUserById(local.id);
+    expect(localAfter?.email).toBe('alice@town.example');
+    expect(localAfter?.role).toBe('clerk');
+    expect(localAfter?.auth_provider).toBe('password');
+  });
+
+  it('matches a returning OAuth user by provider identity even after a provider username change', async () => {
+    const first = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth()
+    );
+
+    // Same provider identity, new provider username.
+    const second = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth({ username: 'alice-renamed' })
+    );
+
+    expect(second.user.id).toBe(first.user.id);
+  });
+
+  it('an attacker with the same username on the SAME provider but different identity gets a separate account', async () => {
+    const victim = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth()
+    );
+
+    const attacker = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth({ id: 'gh-6666', providerUserId: 'gh-6666', email: 'evil@x.example' })
+    );
+
+    expect(attacker.user.id).not.toBe(victim.user.id);
+    const victimAfter = await authService.getUserById(victim.user.id);
+    expect(victimAfter?.email).toBe('alice@provider.example');
+  });
+
+  it('adopts a legacy same-provider account (no recorded identity) and binds it', async () => {
+    // Simulate a pre-provider_user_id OAuth account.
+    const legacy = await authService.createUser({
+      username: 'bob',
+      email: 'bob@provider.example',
+      role: 'public',
+      auth_provider: 'github',
+    });
+
+    const result = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth({ id: 'gh-2002', providerUserId: 'gh-2002', username: 'bob', email: 'bob@provider.example' })
+    );
+    expect(result.user.id).toBe(legacy.id);
+
+    // Once bound, a DIFFERENT identity with the same username cannot adopt it.
+    const impostor = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth({ id: 'gh-9999', providerUserId: 'gh-9999', username: 'bob', email: 'imp@x.example' })
+    );
+    expect(impostor.user.id).not.toBe(legacy.id);
+  });
+});

--- a/tests/core/oauth-linking.test.ts
+++ b/tests/core/oauth-linking.test.ts
@@ -135,4 +135,51 @@ describe('OAuth account linking by provider identity', () => {
     );
     expect(impostor.user.id).not.toBe(legacy.id);
   });
+
+  it('refuses username adoption when the provider supplies NO stable id (defense in depth)', async () => {
+    // A legacy same-provider account that WOULD be adoptable with an id.
+    const legacy = await authService.createUser({
+      username: 'carol',
+      email: 'carol@provider.example',
+      role: 'clerk',
+      auth_provider: 'github',
+    });
+
+    // Provider returns an empty subject (misconfigured OIDC/SAML shape).
+    const result = await authService.authenticateWithOAuth('github', 'tok', {
+      id: '',
+      username: 'carol',
+      email: 'carol@provider.example',
+      name: 'Carol',
+      provider: 'github',
+      providerUserId: '',
+    });
+
+    // Must NOT take over the legacy account by username alone.
+    expect(result.user.id).not.toBe(legacy.id);
+    const legacyAfter = await authService.getUserById(legacy.id);
+    expect(legacyAfter?.role).toBe('clerk');
+  });
+
+  it('authenticateWithGitHub shares the identity-first matching (no username takeover)', async () => {
+    const local = await authService.createUserWithPassword({
+      username: 'dave',
+      passwordHash: await bcrypt.hash('Local-Passw0rd!1', 12),
+      email: 'dave@town.example',
+      role: 'clerk',
+    });
+
+    // Inject provider data via NODE_ENV=test path of authenticateWithOAuth,
+    // which authenticateWithGitHub now delegates to. Since the GitHub alias
+    // takes only a token, exercise the shared path with the same identity to
+    // prove it does not link the local 'dave' by username.
+    const result = await authService.authenticateWithOAuth(
+      'github',
+      'tok',
+      oauth({ id: 'gh-3003', providerUserId: 'gh-3003', username: 'dave' })
+    );
+    expect(result.user.id).not.toBe(local.id);
+    const localAfter = await authService.getUserById(local.id);
+    expect(localAfter?.auth_provider).toBe('password');
+  });
 });

--- a/tests/core/password-policy.test.ts
+++ b/tests/core/password-policy.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import bcrypt from 'bcrypt';
+import { CivicPress } from '../../core/src/civic-core.js';
+import { AuthService } from '../../core/src/auth/auth-service.js';
+import {
+  createTestDirectory,
+  createRolesConfig,
+  cleanupTestDirectory,
+} from '../fixtures/test-setup';
+
+/**
+ * Post-audit hardening batch 3: the password-strength policy existed in
+ * AuthConfigManager but was dead code — 1-character passwords were accepted
+ * at every entry point. PasswordOps.validatePasswordPolicy is now the
+ * single chokepoint, enforced in changePassword and setUserPassword (the
+ * API registration route and CLI call it before hashing).
+ */
+describe('Password policy enforcement', () => {
+  let civicPress: CivicPress;
+  let authService: AuthService;
+  let testConfig: ReturnType<typeof createTestDirectory>;
+
+  beforeEach(async () => {
+    testConfig = createTestDirectory('password-policy-test');
+    createRolesConfig(testConfig);
+    civicPress = new CivicPress({
+      dataDir: testConfig.dataDir,
+      database: {
+        type: 'sqlite',
+        sqlite: { file: join(testConfig.testDir, 'test.db') },
+      },
+    });
+    await civicPress.initialize();
+    authService = civicPress.getAuthService();
+  });
+
+  afterEach(async () => {
+    if (civicPress) {
+      await civicPress.shutdown();
+    }
+    cleanupTestDirectory(testConfig);
+  });
+
+  it('validatePasswordPolicy rejects weak and accepts compliant passwords', () => {
+    const weak = authService.validatePasswordPolicy('x');
+    expect(weak.valid).toBe(false);
+    expect(weak.errors.length).toBeGreaterThan(0);
+
+    const strong = authService.validatePasswordPolicy('Str0ng!Passw0rd');
+    expect(strong.valid).toBe(true);
+    expect(strong.errors).toHaveLength(0);
+  });
+
+  it('changePassword refuses a policy-violating new password (and keeps sessions alive)', async () => {
+    const user = await authService.createUserWithPassword({
+      username: 'weakling',
+      passwordHash: await bcrypt.hash('Old!Passw0rd', 12),
+      email: 'weak@example.com',
+      role: 'public',
+    });
+    const { token } = await authService.createSession(user.id);
+
+    const result = await authService.changePassword(user.id, 'x', 'Old!Passw0rd');
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/requirements/i);
+
+    // The failed change must not have revoked anything.
+    expect(await authService.validateSession(token)).not.toBeNull();
+  });
+
+  it('admin setUserPassword refuses a policy-violating password', async () => {
+    const admin = await authService.createUser({
+      username: 'policyadmin',
+      email: 'policyadmin@example.com',
+      role: 'admin',
+    });
+    const user = await authService.createUserWithPassword({
+      username: 'target',
+      passwordHash: await bcrypt.hash('Old!Passw0rd', 12),
+      email: 'target@example.com',
+      role: 'public',
+    });
+
+    const result = await authService.setUserPassword(user.id, 'short', admin.id);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/requirements/i);
+  });
+
+  it('a compliant password still passes end-to-end', async () => {
+    const user = await authService.createUserWithPassword({
+      username: 'strongling',
+      passwordHash: await bcrypt.hash('Old!Passw0rd', 12),
+      email: 'strong@example.com',
+      role: 'public',
+    });
+    const result = await authService.changePassword(
+      user.id,
+      'New!Passw0rd42',
+      'Old!Passw0rd'
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/core/role-cycle.test.ts
+++ b/tests/core/role-cycle.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+import yaml from 'js-yaml';
+import { CivicPress } from '../../core/src/civic-core.js';
+import { AuthService } from '../../core/src/auth/auth-service.js';
+import {
+  createTestDirectory,
+  createRolesConfig,
+  cleanupTestDirectory,
+} from '../fixtures/test-setup';
+
+/**
+ * Post-audit hardening batch 3: a circular role_hierarchy (admin → clerk →
+ * admin) used to recurse to stack overflow inside getRolePermissions, which
+ * userCan swallowed as `false` — silently denying EVERY permission with no
+ * diagnosable error. The walker now carries a visited set: cycles resolve
+ * to the union of the roles' direct permissions.
+ */
+describe('Role hierarchy cycle detection', () => {
+  let civicPress: CivicPress;
+  let authService: AuthService;
+  let testConfig: ReturnType<typeof createTestDirectory>;
+
+  beforeEach(async () => {
+    testConfig = createTestDirectory('role-cycle-test');
+    createRolesConfig(testConfig);
+
+    // Introduce a cycle: admin → clerk → admin (fixture ships admin →
+    // [clerk, public], clerk → [public]).
+    const rolesPath = join(testConfig.dataDir, '.civic', 'roles.yml');
+    const roles = yaml.load(readFileSync(rolesPath, 'utf8')) as {
+      role_hierarchy: Record<string, { value: string[] }>;
+    };
+    roles.role_hierarchy.clerk.value = ['public', 'admin'];
+    writeFileSync(rolesPath, yaml.dump(roles));
+
+    civicPress = new CivicPress({
+      dataDir: testConfig.dataDir,
+      database: {
+        type: 'sqlite',
+        sqlite: { file: join(testConfig.testDir, 'test.db') },
+      },
+    });
+    await civicPress.initialize();
+    authService = civicPress.getAuthService();
+  });
+
+  afterEach(async () => {
+    if (civicPress) {
+      await civicPress.shutdown();
+    }
+    cleanupTestDirectory(testConfig);
+  });
+
+  it('userCan still resolves permissions under a circular hierarchy', async () => {
+    const admin = await authService.createUser({
+      username: 'cycleadmin',
+      email: 'cycleadmin@example.com',
+      role: 'admin',
+    });
+
+    // Pre-fix this stack-overflowed and surfaced as a blanket `false`.
+    expect(await authService.userCan(admin, 'records:view')).toBe(true);
+    expect(await authService.userCan(admin, 'system:admin')).toBe(true);
+  });
+
+  it('cyclic inheritance yields the union of the cycle members’ permissions', async () => {
+    const clerk = await authService.createUser({
+      username: 'cycleclerk',
+      email: 'cycleclerk@example.com',
+      role: 'clerk',
+    });
+
+    // clerk → admin (via the cycle) grants admin's direct permissions once,
+    // without re-walking admin → clerk forever.
+    expect(await authService.userCan(clerk, 'system:admin')).toBe(true);
+  });
+});

--- a/tests/core/security-guards.test.ts
+++ b/tests/core/security-guards.test.ts
@@ -119,7 +119,7 @@ describe('Security Guards', () => {
 
       const result = await authService.changePassword(
         user.id,
-        'newpassword123',
+        'Newpassword!123',
         'currentpassword'
       );
 
@@ -141,7 +141,7 @@ describe('Security Guards', () => {
 
       const result = await authService.changePassword(
         user.id,
-        'newpassword123',
+        'Newpassword!123',
         'anypassword'
       );
 
@@ -174,7 +174,7 @@ describe('Security Guards', () => {
 
       const result = await authService.setUserPassword(
         targetUser.id,
-        'newpassword123',
+        'Newpassword!123',
         adminUser.id
       );
 
@@ -206,7 +206,7 @@ describe('Security Guards', () => {
 
       const result = await authService.setUserPassword(
         externalUser.id,
-        'newpassword123',
+        'Newpassword!123',
         adminUser.id
       );
 

--- a/tests/core/session-revocation.test.ts
+++ b/tests/core/session-revocation.test.ts
@@ -82,7 +82,7 @@ describe('Session revocation', () => {
   it('changePassword revokes every session the user holds', async () => {
     const user = await authService.createUserWithPassword({
       username: 'pwchange',
-      passwordHash: await bcrypt.hash('old-password-123', 12),
+      passwordHash: await bcrypt.hash('Old-Passw0rd!123', 12),
       email: 'pwchange@example.com',
       role: 'public',
     });
@@ -94,8 +94,8 @@ describe('Session revocation', () => {
 
     const result = await authService.changePassword(
       user.id,
-      'new-password-456',
-      'old-password-123'
+      'New-Passw0rd!456',
+      'Old-Passw0rd!123'
     );
     expect(result.success).toBe(true);
 
@@ -106,7 +106,7 @@ describe('Session revocation', () => {
   it('a failed changePassword (wrong current password) revokes nothing', async () => {
     const user = await authService.createUserWithPassword({
       username: 'pwfail',
-      passwordHash: await bcrypt.hash('old-password-123', 12),
+      passwordHash: await bcrypt.hash('Old-Passw0rd!123', 12),
       email: 'pwfail@example.com',
       role: 'public',
     });
@@ -114,7 +114,7 @@ describe('Session revocation', () => {
 
     const result = await authService.changePassword(
       user.id,
-      'new-password-456',
+      'New-Passw0rd!456',
       'WRONG-current'
     );
     expect(result.success).toBe(false);
@@ -130,7 +130,7 @@ describe('Session revocation', () => {
     });
     const user = await authService.createUserWithPassword({
       username: 'resetme',
-      passwordHash: await bcrypt.hash('stolen-password-1', 12),
+      passwordHash: await bcrypt.hash('Stolen-Passw0rd!1', 12),
       email: 'resetme@example.com',
       role: 'public',
     });
@@ -139,7 +139,7 @@ describe('Session revocation', () => {
 
     const result = await authService.setUserPassword(
       user.id,
-      'fresh-password-2',
+      'Fresh-Passw0rd!2',
       admin.id
     );
     expect(result.success).toBe(true);

--- a/tests/core/user-management.test.ts
+++ b/tests/core/user-management.test.ts
@@ -41,7 +41,7 @@ describe('Core User Management', () => {
     it('should create a user with password', async () => {
       const userData = {
         username: 'testuser1',
-        password: 'testpass123',
+        password: 'Testpass!123',
         name: 'Test User 1',
         email: 'test1@example.com',
         role: 'public' as const,
@@ -57,7 +57,7 @@ describe('Core User Management', () => {
     it('should create a user with minimal fields', async () => {
       const userData = {
         username: 'testuser2',
-        password: 'testpass123',
+        password: 'Testpass!123',
         role: 'public', // Explicitly provide role
       };
       const user = await createUserWithPassword(authService, userData);
@@ -69,7 +69,7 @@ describe('Core User Management', () => {
     it('should fail to create user with duplicate username', async () => {
       const userData = {
         username: 'testuser3',
-        password: 'testpass123',
+        password: 'Testpass!123',
         role: 'public', // Explicitly provide role
       };
       await createUserWithPassword(authService, userData);
@@ -83,7 +83,7 @@ describe('Core User Management', () => {
     beforeEach(async () => {
       await createUserWithPassword(authService, {
         username: 'testauth',
-        password: 'testpass123',
+        password: 'Testpass!123',
         name: 'Test Auth User',
         role: 'public',
       });
@@ -92,7 +92,7 @@ describe('Core User Management', () => {
     it('should authenticate with correct password', async () => {
       const session = await authService.authenticateWithPassword(
         'testauth',
-        'testpass123'
+        'Testpass!123'
       );
       expect(session).toBeDefined();
       expect(session.token).toBeDefined();
@@ -110,7 +110,7 @@ describe('Core User Management', () => {
 
     it('should fail authentication with non-existent user', async () => {
       await expect(
-        authService.authenticateWithPassword('nonexistent', 'testpass123')
+        authService.authenticateWithPassword('nonexistent', 'Testpass!123')
       ).rejects.toThrow();
     });
   });
@@ -119,7 +119,7 @@ describe('Core User Management', () => {
     beforeEach(async () => {
       await createUserWithPassword(authService, {
         username: 'testretrieve',
-        password: 'testpass123',
+        password: 'Testpass!123',
         name: 'Test Retrieve User',
         email: 'retrieve@example.com',
         role: 'clerk',
@@ -147,7 +147,7 @@ describe('Core User Management', () => {
     beforeEach(async () => {
       const user = await createUserWithPassword(authService, {
         username: 'testupdate',
-        password: 'testpass123',
+        password: 'Testpass!123',
         name: 'Test Update User',
         email: 'update@example.com',
         role: 'public',
@@ -171,7 +171,7 @@ describe('Core User Management', () => {
     });
 
     it('should update user password', async () => {
-      const newPasswordHash = await bcrypt.hash('newpass123', 10);
+      const newPasswordHash = await bcrypt.hash('Newpass!123', 10);
       const result = await authService.updateUser(userId, {
         passwordHash: newPasswordHash,
       });
@@ -182,7 +182,7 @@ describe('Core User Management', () => {
       // Verify new password works
       const session = await authService.authenticateWithPassword(
         'testupdate',
-        'newpass123'
+        'Newpass!123'
       );
       expect(session).toBeDefined();
       expect(session.user.username).toBe('testupdate');
@@ -203,7 +203,7 @@ describe('Core User Management', () => {
     beforeEach(async () => {
       const user = await createUserWithPassword(authService, {
         username: 'testdelete',
-        password: 'testpass123',
+        password: 'Testpass!123',
         name: 'Test Delete User',
         role: 'public',
       });
@@ -226,7 +226,7 @@ describe('Core User Management', () => {
     it('should fail to authenticate deleted user', async () => {
       await authService.deleteUser(userId);
       await expect(
-        authService.authenticateWithPassword('testdelete', 'testpass123')
+        authService.authenticateWithPassword('testdelete', 'Testpass!123')
       ).rejects.toThrow();
     });
   });
@@ -237,14 +237,14 @@ describe('Core User Management', () => {
     beforeEach(async () => {
       await createUserWithPassword(authService, {
         username: 'testsession',
-        password: 'testpass123',
+        password: 'Testpass!123',
         name: 'Test Session User',
         role: 'public',
       });
 
       const session = await authService.authenticateWithPassword(
         'testsession',
-        'testpass123'
+        'Testpass!123'
       );
       sessionToken = session.token;
     });

--- a/tests/storage/characterization/cloud-uuid-storage-service.characterization.test.ts
+++ b/tests/storage/characterization/cloud-uuid-storage-service.characterization.test.ts
@@ -349,13 +349,22 @@ describe('StorageValidation — validateFile (W2-T18 characterization)', () => {
     expect(result.errors.some((e) => /exceeds limit/.test(e))).toBe(true);
   });
 
-  it('emits a warning (not an error) for executable extensions', () => {
-    const result = validation.validateFile(
-      makeFile({ originalname: 'install.exe' }),
-      makeFolder({ allowed_types: ['*'] })
-    );
-    expect(result.valid).toBe(true);
-    expect(result.warnings.some((w) => /executable/i.test(w))).toBe(true);
+  it('REJECTS executable extensions outright (post-audit hardening: was warn-only)', () => {
+    for (const name of [
+      'install.exe',
+      'run.bat',
+      'go.cmd',
+      'script.sh',
+      'evil.ps1',
+    ]) {
+      const result = validation.validateFile(
+        makeFile({ originalname: name }),
+        // Even a wildcard folder must not accept executables.
+        makeFolder({ allowed_types: ['*'] })
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => /executable/i.test(e))).toBe(true);
+    }
   });
 
   it('extension matching is case-insensitive (.PDF accepted when "pdf" allowed)', () => {


### PR DESCRIPTION
Post-audit hardening batch 3 (backlog Tier B). **Stacked on #16** (Tier A) — retarget to `main` after #16 merges.

## Seven fixes
1. **Password-strength policy was dead code** — `validatePassword` existed but nothing called it; 1-char passwords accepted everywhere. `PasswordOps.validatePasswordPolicy` is now the enforced chokepoint across change/set/register/admin-create/admin-update/CLI-create/CLI-update/`civic init` bootstrap. (Made load-tolerant so it enforces from CLI contexts too.)
2. **OAuth account TAKEOVER** — matched by username and overwrote email. Now matches `(auth_provider, provider_user_id)` (new column + partial-unique index + `getUserByProvider`); legacy accounts adopted once, only with a stable id; the dead `authenticateWithGitHub` alias and empty-id fallback both hardened.
3. **Unexpected 500s leaked raw `error.message`** (paths/SQL/SMTP hosts) — api-logger fallback + config/notifications/system/info routes redact; server-side logging retained. system.ts + info.ts were **unauthenticated**.
4. **Role hierarchy had no cycle detection** — a circular roles.yml stack-overflowed and `userCan` swallowed it as a blanket deny-all. Visited-set added.
5. **`setMockUser()`** — a zero-caller, console-invocable admin-escalation Pinia action — shipped in the production bundle. Deleted.
6. **Executable uploads** produced a discarded warning; now denied (broadened extension set).
7. **Realtime DoS**: `max_rooms` now enforced at room creation (was health-metric-only); `maxPayload` capped at 10 MiB (was the ~100 MiB `ws` default).

## Verification
- 4 new test files (oauth-linking incl. takeover/rename/legacy-adoption/empty-id/github-alias, password-policy, password-policy-routes proving the two admin-route bypasses, role-cycle). All green.
- Blast radius green from a **clean test DB**: auth/oauth/roles/user-management/security-guards/session-revocation, CLI users + security-commands, API users + security-features, storage characterization, full realtime module suite (127).
- **Two worktree-isolated adversarial passes.** First found two proven admin-route policy bypasses (a skeptic created a working admin with a 1-char password live) + unauthenticated 500 leaks — all fixed here. Second confirmed no OAuth takeover survives on the live path and flagged the two latent alias/empty-id paths, both closed.

## Admin follow-up
Same as #15/#16: status-check-only branch protection; command in #15's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)