### PR TITLE
fix: Tier C correctness — storage resilience, config/CLI, API routes, saga rollback, BB wiring, notifications

### DIFF
--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -77,6 +77,9 @@ export default function setupAuthCommand(cli: CAC) {
           options.token
         );
 
+        // Persist where resolveToken() reads it (see login.ts).
+        const tokenFile = AuthUtils.saveToken(session.token);
+
         cliSuccess(
           {
             session: {
@@ -84,8 +87,9 @@ export default function setupAuthCommand(cli: CAC) {
               user: session.user,
               expiresAt: session.expiresAt,
             },
+            tokenFile,
           },
-          `Authentication successful: ${session.user.username}`,
+          `Authentication successful: ${session.user.username} (session saved to ${tokenFile})`,
           {
             operation: 'auth:login',
             provider: options.provider,

--- a/cli/src/commands/history.ts
+++ b/cli/src/commands/history.ts
@@ -61,13 +61,39 @@ export const historyCommand = (cli: CAC) => {
           process.exit(1);
         }
 
+        // When a record is named, scope the log to its file via a pathspec
+        // (git log -- <path>) instead of ignoring the argument entirely, as
+        // this command used to. Resolve the record's real path through a
+        // CivicPress instance; unresolvable → unscoped history.
+        let pathspec: string | undefined;
+        if (record) {
+          try {
+            const { CivicPress, CentralConfigManager } = await import(
+              '@civicpress/core'
+            );
+            const civic = new CivicPress({
+              dataDir,
+              database: CentralConfigManager.getDatabaseConfig(),
+            });
+            await civic.initialize();
+            try {
+              const rec = await civic.getRecordManager().getRecord(record);
+              pathspec = (rec as { path?: string } | null)?.path;
+            } finally {
+              await civic.shutdown();
+            }
+          } catch {
+            // fall back to unscoped history
+          }
+        }
+
         // Get commit history
         const limit = parseInt(options.limit) || 10;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let history: any[] = [];
 
         try {
-          history = await git.getHistory(limit);
+          history = await git.getHistory(limit, pathspec);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
           // Handle case where there are no commits yet

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -2,6 +2,7 @@ import { CAC } from 'cac';
 import { CivicPress } from '@civicpress/core';
 import * as fs from 'fs';
 import inquirer from 'inquirer';
+import { AuthUtils } from '../utils/auth-utils.js';
 import {
   getGlobalOptionsFromArgs,
   initializeCliOutput,
@@ -67,7 +68,7 @@ export const loginCommand = (cli: CAC) => {
 
         if (options.logout) {
           // Handle logout
-          await handleLogout(civic);
+          await handleLogout(civic, options.token);
         } else if (options.status) {
           // Handle status check
           await handleStatus(civic);
@@ -160,6 +161,12 @@ async function handleLogin(civic: CivicPress, options: any): Promise<void> {
       session = await authService.authenticateWithPassword(username, password);
     }
 
+    // Persist the token where resolveToken() reads it, so the very next
+    // command is authenticated without re-passing it. Previously login only
+    // emitted the token in the --json payload (never in human mode and never
+    // to disk), so the login→command loop was broken.
+    const tokenFile = AuthUtils.saveToken(session.token);
+
     cliSuccess(
       {
         session: {
@@ -167,8 +174,9 @@ async function handleLogin(civic: CivicPress, options: any): Promise<void> {
           user: session.user,
           expiresAt: session.expiresAt,
         },
+        tokenFile,
       },
-      `Successfully authenticated as ${session.user.username}`,
+      `Successfully authenticated as ${session.user.username} (session saved to ${tokenFile})`,
       {
         operation: 'login',
         username: session.user.username,
@@ -189,10 +197,18 @@ async function handleLogin(civic: CivicPress, options: any): Promise<void> {
   }
 }
 
-async function handleLogout(civic: CivicPress): Promise<void> {
+async function handleLogout(
+  civic: CivicPress,
+  flagToken?: string
+): Promise<void> {
   try {
     const authService = civic.getAuthService();
-    await authService.logout();
+    // Revoke the presented session server-side (Tier-A session revocation
+    // wired to the CLI), then drop the locally-persisted token so the next
+    // command is no longer authenticated.
+    const token = AuthUtils.getResolvedToken(flagToken);
+    await authService.logout(token);
+    AuthUtils.clearToken();
 
     cliSuccess({ success: true }, 'Successfully logged out', {
       operation: 'logout',

--- a/cli/src/utils/__tests__/auth-utils-token.test.ts
+++ b/cli/src/utils/__tests__/auth-utils-token.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { AuthUtils } from '../auth-utils.js';
+
+/**
+ * Post-audit Tier-C: the CLI login→command loop was broken — resolveToken
+ * reads ~/.civicpress/token but login never wrote it. saveToken/clearToken/
+ * getResolvedToken are the mechanism that closes that loop.
+ */
+describe('AuthUtils token persistence', () => {
+  let home: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'civic-home-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = home;
+    delete process.env.CIVIC_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('saves a token that getResolvedToken then reads back', () => {
+    expect(AuthUtils.getResolvedToken()).toBeUndefined();
+
+    const file = AuthUtils.saveToken('sess-abc.def');
+    expect(file).toBe(AuthUtils.tokenFilePath());
+    expect(existsSync(file)).toBe(true);
+    expect(readFileSync(file, 'utf-8')).toBe('sess-abc.def');
+
+    expect(AuthUtils.getResolvedToken()).toBe('sess-abc.def');
+  });
+
+  it('writes the token file owner-only (0600)', () => {
+    const file = AuthUtils.saveToken('secret');
+    // Low 9 permission bits must be rw for owner only.
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it('clearToken removes the persisted token (idempotent)', () => {
+    AuthUtils.saveToken('sess-1');
+    AuthUtils.clearToken();
+    expect(existsSync(AuthUtils.tokenFilePath())).toBe(false);
+    expect(AuthUtils.getResolvedToken()).toBeUndefined();
+    // Second clear must not throw.
+    expect(() => AuthUtils.clearToken()).not.toThrow();
+  });
+
+  it('precedence: explicit flag beats env beats file', () => {
+    AuthUtils.saveToken('from-file');
+    process.env.CIVIC_TOKEN = 'from-env';
+    expect(AuthUtils.getResolvedToken('from-flag')).toBe('from-flag');
+    expect(AuthUtils.getResolvedToken()).toBe('from-env');
+    delete process.env.CIVIC_TOKEN;
+    expect(AuthUtils.getResolvedToken()).toBe('from-file');
+  });
+});

--- a/cli/src/utils/auth-utils.ts
+++ b/cli/src/utils/auth-utils.ts
@@ -2,13 +2,45 @@ import { CivicPress } from '@civicpress/core';
 import { Logger } from '@civicpress/core';
 import * as path from 'path';
 import * as os from 'os';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 
 /**
  * Authentication utilities for CLI commands
  */
 export class AuthUtils {
   private static logger = new Logger();
+
+  /** The file `resolveToken` reads and `login`/`logout` write. */
+  static tokenFilePath(): string {
+    return path.join(os.homedir(), '.civicpress', 'token');
+  }
+
+  /**
+   * Persist a session token so subsequent commands resolve it without a
+   * flag or env var. Written 0600 (owner-only) — the whole point of the
+   * file (vs `--token`) is to keep the token OUT of shell history and
+   * process listings, so it must not be world-readable either.
+   */
+  static saveToken(token: string): string {
+    const file = this.tokenFilePath();
+    mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    writeFileSync(file, token, { encoding: 'utf-8', mode: 0o600 });
+    return file;
+  }
+
+  /** Remove the persisted token (logout). Idempotent. */
+  static clearToken(): void {
+    try {
+      rmSync(this.tokenFilePath(), { force: true });
+    } catch {
+      // best-effort — nothing to clear
+    }
+  }
+
+  /** Public token resolution (flag → CIVIC_TOKEN → token file). */
+  static getResolvedToken(flagToken?: string): string | undefined {
+    return this.resolveToken(flagToken).token;
+  }
 
   /**
    * FA-CLI-003: a token passed on the command line (`--token`) is visible in

--- a/core/src/auth/role-manager.ts
+++ b/core/src/auth/role-manager.ts
@@ -428,8 +428,19 @@ export class RoleManager {
     // from a legal DIAMOND — admin → [clerk, public] plus clerk → public —
     // which the default roles.yml has. A global visited-set flagged the
     // diamond as a spurious cycle; the path set only fires on true cycles.
-    path: Set<string> = new Set()
+    path: Set<string> = new Set(),
+    // Memo of FULLY-resolved roles within this call. Restores O(V+E): a
+    // diamond node reached by a second path returns its cached union instead
+    // of re-walking its subtree (which is exponential on nested diamonds
+    // without this). Only complete resolutions are memoized — a cycle-broken
+    // `[]` is never cached, so it can't poison a legitimate resolution.
+    memo: Map<string, string[]> = new Map()
   ): string[] {
+    const cached = memo.get(role);
+    if (cached) {
+      return cached;
+    }
+
     const permissions = new Set<string>();
 
     // Cycle guard: a circular role_hierarchy used to recurse to stack
@@ -533,7 +544,8 @@ export class RoleManager {
         const inheritedPermissions = this.getRolePermissions(
           inheritedRole,
           config,
-          path
+          path,
+          memo
         );
         inheritedPermissions.forEach((p) => permissions.add(p));
       }
@@ -603,6 +615,8 @@ export class RoleManager {
       // Backtrack: leave the DFS path so a sibling branch that reaches this
       // same role (a legal diamond) is not mistaken for a cycle.
       path.delete(role);
+      // Memoize the fully-resolved union so a later diamond path reuses it.
+      memo.set(role, finalPermissions);
 
       return finalPermissions;
     } catch (error) {

--- a/core/src/auth/role-manager.ts
+++ b/core/src/auth/role-manager.ts
@@ -422,20 +422,26 @@ export class RoleManager {
   private getRolePermissions(
     role: string,
     config: RolesConfig,
-    visited: Set<string> = new Set()
+    // `path` is the ANCESTOR chain on the current DFS branch, not every role
+    // ever visited. Tracking the path (not a global visited-set) distinguishes
+    // a real CYCLE — a back-edge to an ancestor, e.g. admin → clerk → admin —
+    // from a legal DIAMOND — admin → [clerk, public] plus clerk → public —
+    // which the default roles.yml has. A global visited-set flagged the
+    // diamond as a spurious cycle; the path set only fires on true cycles.
+    path: Set<string> = new Set()
   ): string[] {
     const permissions = new Set<string>();
 
-    // Cycle guard: a circular role_hierarchy (e.g. admin → clerk → admin)
-    // used to recurse to stack overflow, which userCan then swallowed as
-    // `false` — silently denying EVERY permission with no diagnosable error.
-    if (visited.has(role)) {
+    // Cycle guard: a circular role_hierarchy used to recurse to stack
+    // overflow, which userCan then swallowed as `false` — silently denying
+    // EVERY permission with no diagnosable error.
+    if (path.has(role)) {
       logger.warn(
-        `[RoleManager] Circular role inheritance detected at '${role}' (chain: ${[...visited].join(' → ')}) — check role_hierarchy in roles.yml`
+        `[RoleManager] Circular role inheritance detected at '${role}' (chain: ${[...path, role].join(' → ')}) — check role_hierarchy in roles.yml`
       );
       return [];
     }
-    visited.add(role);
+    path.add(role);
 
     logger.debug(`[RoleManager] Getting permissions for role: ${role}`);
 
@@ -527,7 +533,7 @@ export class RoleManager {
         const inheritedPermissions = this.getRolePermissions(
           inheritedRole,
           config,
-          visited
+          path
         );
         inheritedPermissions.forEach((p) => permissions.add(p));
       }
@@ -593,6 +599,10 @@ export class RoleManager {
       logger.debug(
         `[RoleManager] Final permissions for role ${role}`
       );
+
+      // Backtrack: leave the DFS path so a sibling branch that reaches this
+      // same role (a legal diamond) is not mistaken for a cycle.
+      path.delete(role);
 
       return finalPermissions;
     } catch (error) {

--- a/core/src/config/central-config.ts
+++ b/core/src/config/central-config.ts
@@ -140,20 +140,13 @@ export class CentralConfigManager {
       return this.config;
     }
 
-    // Check environment variable first
+    // CIVIC_DATA_DIR overrides ONLY the data directory (applied after the
+    // merge below). It used to early-return a minimal {dataDir, sqlite}
+    // config, which silently dropped the entire .civicrc — auth config,
+    // a postgres/custom database block, everything — whenever the env var
+    // was set. Now .civicrc is still loaded and merged; the env var just
+    // wins for dataDir.
     const envDataDir = process.env.CIVIC_DATA_DIR;
-    if (envDataDir) {
-      this.config = {
-        dataDir: envDataDir,
-        database: {
-          type: 'sqlite',
-          sqlite: {
-            file: path.join(envDataDir, 'civic.db'),
-          },
-        },
-      };
-      return this.config;
-    }
 
     // Find .civicrc file
     const configPath = this.findConfigFile();
@@ -204,6 +197,20 @@ export class CentralConfigManager {
 
     // Merge configs (fallback fills missing fields)
     const mergedConfig = { ...fallbackConfig, ...mainConfig };
+
+    // CIVIC_DATA_DIR override: force the data directory, but keep everything
+    // else the merged .civicrc provided. If .civicrc named no database, fall
+    // back to a sqlite file under the env data dir (the old behavior) — but a
+    // database block from .civicrc (postgres, custom sqlite path) is honored.
+    if (envDataDir) {
+      mergedConfig.dataDir = path.resolve(envDataDir);
+      if (!mergedConfig.database) {
+        mergedConfig.database = {
+          type: 'sqlite',
+          sqlite: { file: path.join(path.resolve(envDataDir), 'civic.db') },
+        };
+      }
+    }
 
     // Check for missing required fields and warn if fallback was used
     const requiredFields = ['dataDir', 'database'] as const;

--- a/core/src/git/__tests__/git-engine-history-pathspec.test.ts
+++ b/core/src/git/__tests__/git-engine-history-pathspec.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import { GitEngine } from '../git-engine.js';
+
+/**
+ * Post-audit Tier-C: record history is now scoped by a git PATHSPEC on the
+ * record's file (git log -- <path>), not a commit-message substring match.
+ * The message match both missed commits that touched the file without naming
+ * it and matched unrelated commits that merely mentioned the id.
+ */
+describe('GitEngine.getHistory pathspec scoping', () => {
+  let repoDir: string;
+  let engine: GitEngine;
+
+  beforeEach(async () => {
+    repoDir = mkdtempSync(join(tmpdir(), 'civic-history-'));
+    execSync('git init', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git config user.email "t@civicpress.example"', { cwd: repoDir });
+    execSync('git config user.name "civic-test"', { cwd: repoDir });
+    engine = new GitEngine(repoDir);
+    await engine.initialize();
+
+    // Commit 1: create records/policy/target.md — message does NOT name the file.
+    writeFileSync(join(repoDir, 'target.md'), 'v1\n');
+    await engine.commit('initial import', ['target.md']);
+
+    // Commit 2: an UNRELATED file, but the message MENTIONS 'target.md'.
+    writeFileSync(join(repoDir, 'other.md'), 'other\n');
+    await engine.commit('note about target.md but touches other', ['other.md']);
+
+    // Commit 3: modify target.md — message again does NOT name it.
+    writeFileSync(join(repoDir, 'target.md'), 'v2\n');
+    await engine.commit('revise the file', ['target.md']);
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('returns exactly the commits that TOUCHED the path, regardless of message', async () => {
+    const history = await engine.getHistory(undefined, 'target.md');
+    const messages = history.map((c) => c.message);
+
+    // Both commits that touched target.md — even though neither names it.
+    expect(messages).toContain('initial import');
+    expect(messages).toContain('revise the file');
+    // The commit that only MENTIONS target.md (touched other.md) is excluded.
+    expect(messages).not.toContain('note about target.md but touches other');
+    expect(history).toHaveLength(2);
+  });
+
+  it('unscoped history (no pathspec) still returns all commits', async () => {
+    const all = await engine.getHistory();
+    expect(all.length).toBe(3);
+  });
+});

--- a/core/src/git/git-engine.ts
+++ b/core/src/git/git-engine.ts
@@ -134,12 +134,23 @@ export class GitEngine {
   }
 
   /**
-   * Get commit history
+   * Get commit history. When `pathspec` is given, the log is scoped to that
+   * path (`git log -- <pathspec>`) — the correct way to get a single record's
+   * history. Callers previously substring-matched commit MESSAGES for the
+   * record id, which both missed commits touching the file without naming it
+   * and matched unrelated commits that happened to mention the id.
    */
-  async getHistory(limit?: number): Promise<GitCommit[]> {
+  async getHistory(limit?: number, pathspec?: string): Promise<GitCommit[]> {
     try {
       const git = this.getGit();
-      const options = limit ? ['-n', limit.toString()] : [];
+      const options: Record<string, unknown> = {};
+      if (limit) {
+        options.maxCount = limit;
+      }
+      if (pathspec) {
+        // simple-git scopes the log to this path when `file` is set.
+        options.file = pathspec;
+      }
       const log = await git.log(options);
       return Array.from(log.all);
     } catch (error) {

--- a/core/src/notifications/notification-service.ts
+++ b/core/src/notifications/notification-service.ts
@@ -247,6 +247,15 @@ export class NotificationService {
     const channel = this.channels.get(channelName);
 
     if (!channel) {
+      // sms/slack are declared in the config schema (with defaults + rate
+      // limits) but no channel implementation was ever built — only email
+      // exists. Say so plainly rather than a generic "not found", so an
+      // operator who enables them isn't left guessing.
+      if (channelName === 'sms' || channelName === 'slack') {
+        throw new Error(
+          `Channel '${channelName}' is configurable but not implemented (only 'email' is available)`
+        );
+      }
       throw new Error(`Channel not found: ${channelName}`);
     }
 
@@ -257,6 +266,21 @@ export class NotificationService {
     }
 
     const recipient = this.getChannelRecipient(request, channelName);
+
+    // A blank recipient used to be dispatched anyway (getChannelRecipient
+    // returns '' for a missing address) and logged as "sent successfully".
+    // Fail loudly instead — a notification to nobody is never a success.
+    if (!recipient || !recipient.trim()) {
+      throw new Error(
+        `No recipient for channel '${channelName}' (missing ${
+          channelName === 'sms'
+            ? 'phone'
+            : channelName === 'slack'
+              ? 'userId'
+              : 'email'
+        })`
+      );
+    }
 
     // Send via channel
     await channel.send({

--- a/core/src/saga/publish-draft-saga.ts
+++ b/core/src/saga/publish-draft-saga.ts
@@ -42,6 +42,8 @@ export interface PublishDraftContext extends SagaContext {
   commitHash?: string;
   /** Whether record already existed (for compensation logic) */
   recordExisted?: boolean;
+  /** Snapshot of the deleted draft (captured in step 4 to enable rollback) */
+  deletedDraftBackup?: Record<string, unknown>;
 }
 
 /**
@@ -412,6 +414,14 @@ class DeleteDraftStep extends BaseSagaStep<PublishDraftContext, void> {
     this.logStep('start', context);
 
     try {
+      // Snapshot the draft BEFORE deleting so compensate() can restore it.
+      // Fire-and-forget steps run after this one, but a future failing step
+      // (or a DB hiccup) would otherwise lose the draft permanently while the
+      // irreversible git commit stands.
+      const backup = await this.db.getDraft(context.draftId);
+      if (backup) {
+        context.deletedDraftBackup = backup as Record<string, unknown>;
+      }
       await this.db.deleteDraft(context.draftId);
       this.logStep('complete', context);
     } catch (error) {
@@ -421,16 +431,47 @@ class DeleteDraftStep extends BaseSagaStep<PublishDraftContext, void> {
   }
 
   async compensate(context: PublishDraftContext): Promise<void> {
-    // If draft was deleted but saga failed, we can't easily restore it
-    // This is a limitation - in production, we might want to store draft backup
-    // For now, log a warning
-    coreDebug(
-      `Draft ${context.draftId} was deleted but saga failed - manual intervention may be needed`,
-      {
+    const backup = context.deletedDraftBackup;
+    if (!backup) {
+      coreDebug(
+        `Draft ${context.draftId} deletion had no backup to restore`,
+        { draftId: context.draftId, correlationId: context.correlationId }
+      );
+      return;
+    }
+    try {
+      // Re-create the draft from the snapshot so a failed publish leaves the
+      // author's work intact (no manual intervention needed).
+      await this.db.createDraft({
+        id: String(backup.id),
+        title: String(backup.title),
+        type: String(backup.type),
+        status: backup.status as string | undefined,
+        workflow_state: backup.workflow_state as string | undefined,
+        markdown_body: (backup.markdown_body as string | null) ?? null,
+        metadata: (backup.metadata as string | null) ?? null,
+        geography: (backup.geography as string | null) ?? null,
+        attached_files: (backup.attached_files as string | null) ?? null,
+        linked_records: (backup.linked_records as string | null) ?? null,
+        linked_geography_files:
+          (backup.linked_geography_files as string | null) ?? null,
+        author: String(backup.author ?? ''),
+        created_by: String(backup.created_by ?? backup.author ?? ''),
+      });
+      coreDebug(`Restored draft ${context.draftId} after saga rollback`, {
         draftId: context.draftId,
         correlationId: context.correlationId,
-      }
-    );
+      });
+    } catch (error) {
+      coreError(
+        `Failed to restore draft ${context.draftId} during compensation`,
+        'SAGA_DRAFT_RESTORE_ERROR',
+        {
+          draftId: context.draftId,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
+    }
   }
 }
 

--- a/core/src/saga/publish-draft-saga.ts
+++ b/core/src/saga/publish-draft-saga.ts
@@ -441,7 +441,11 @@ class DeleteDraftStep extends BaseSagaStep<PublishDraftContext, void> {
     }
     try {
       // Re-create the draft from the snapshot so a failed publish leaves the
-      // author's work intact (no manual intervention needed).
+      // author's CONTENT intact (no manual intervention needed). Note:
+      // createDraft does not accept timestamps, so the restored draft gets
+      // fresh created_at/updated_at/last_draft_saved_at — content and all
+      // fields are preserved, only the original save times are not. That is
+      // an acceptable trade for a rare rollback path.
       await this.db.createDraft({
         id: String(backup.id),
         title: String(backup.title),

--- a/docs/backlog/2026-07-post-audit-hardening.md
+++ b/docs/backlog/2026-07-post-audit-hardening.md
@@ -118,6 +118,14 @@ follow-up. (Storage, config+CLI, API-routes clusters + saga/BB/notifications.)
 
 ## Test & CI health
 
+- [ ] **Tier-C skeptic coverage-gap follow-up:** the geography `/linked-records`
+  batch-scan fix has no test — add one that seeds >`LINKED_RECORDS_SCAN_CAP`
+  (1000) records with a subset linking the geography across multiple pages and
+  asserts the total is correct + no rows past page 1 are dropped. (The fix
+  itself was skeptic-verified correct; termination is safe by inspection. The
+  history-pathspec sibling gap IS now covered by
+  `core/src/git/__tests__/git-engine-history-pathspec.test.ts`.)
+
 - [ ] **QUARANTINE BURN-DOWN (added with the CI batch — top of this tier):**
   5 files / 11 tests fail deterministically from a CLEAN checkout of main and
   are excluded in CI only via `CIVIC_TEST_QUARANTINE=1` (list in

--- a/docs/backlog/2026-07-post-audit-hardening.md
+++ b/docs/backlog/2026-07-post-audit-hardening.md
@@ -55,18 +55,22 @@ Status legend: `[ ]` open · `[~]` in progress · `[x]` landed+verified · `[-]`
 
 ## Tier C — correctness bugs (SCOUTED 2026-07-16, file:line below)
 
-- [ ] Storage streaming (`modules/storage/.../streaming-ops.ts`): GCS missing from the switch (L142-180, throws at L178); stream path bypasses failover/retry/metrics (calls uploadStreamTo* directly, no StorageFailoverManager); S3/Azure streamed `size` persisted as 0 (L164/L176 `request.size||0`, comment "provider will set size" is false → breaks quota)
-- [ ] `updateFile` (`file-mgmt-ops.ts:273-291`) never invalidates folder cache (dead `invalidateFile` at `storage-metadata-cache-adapter.ts:124`); failover-on-read returns `null` as "success" so it never fails over to the provider holding the object (`download-ops.ts` L159/L191/L306 return null; `storage-failover-manager.ts:100` treats resolved null as success)
-- [ ] `CIVIC_DATA_DIR` (`central-config.ts:144-156`): early-return hardcodes sqlite path AND skips the entire `.civicrc` load/merge (drops `auth` + all other config)
-- [ ] CLI login token (`login.ts:163-177` / `auth.ts:80-95`): never writes `~/.civicpress/token` that `resolveToken` reads (`auth-utils.ts:31-38`); human mode never prints the token either
-- [ ] geography `/linked-records` (`geography.ts:448-499`, cap L27) loses rows past 1000 + wrong total/totalPages; `/records/:id/raw` (`read-handlers.ts:374`) missing `optionalAuth` → editors always treated as public
-- [ ] record-history filter: no-op `.replace('/','/')` substring match (`history.ts:103,263`); CLI `civic history` ignores the record arg entirely (`history.ts:70`). Fix = pathspec-scoped `GitEngine.getHistory` (`git-engine.ts:139`)
-- [ ] publishDraft ordering (`publish-draft-saga.ts` steps L552-559): DeleteDraftStep (L402) runs after the irreversible CommitToGitStep (L362, isCompensatable=false) with a log-only no-op compensation (L423) → DB hiccup loses a committed record's draft unrecoverably
-- [ ] BB device health-monitor + stale-reaper implemented (`device-connection-tracker.ts:304`/`335`) but never started in production; wire at the tracker factory (`broadcast-box-services.ts:294-310`)
-- [ ] UI: `useMarkdown` heading inline formatting; autosave timer unmount; editor host collab-vs-CM latch at mount
-- [ ] HW multi-output ffmpeg filtergraph pad reuse (`[v_wm]` mapped twice)
+**Batch 4 landed on `refactor/phase-7d-tier-c` (stacked on #17):** all 9
+findings below fixed across 4 thematic commits + a role-manager diamond
+follow-up. (Storage, config+CLI, API-routes clusters + saga/BB/notifications.)
+
+- [x] Storage streaming (`modules/storage/.../streaming-ops.ts`): GCS missing from the switch (L142-180, throws at L178); stream path bypasses failover/retry/metrics (calls uploadStreamTo* directly, no StorageFailoverManager); S3/Azure streamed `size` persisted as 0 (L164/L176 `request.size||0`, comment "provider will set size" is false → breaks quota)
+- [x] `updateFile` (`file-mgmt-ops.ts:273-291`) never invalidates folder cache (dead `invalidateFile` at `storage-metadata-cache-adapter.ts:124`); failover-on-read returns `null` as "success" so it never fails over to the provider holding the object (`download-ops.ts` L159/L191/L306 return null; `storage-failover-manager.ts:100` treats resolved null as success)
+- [x] `CIVIC_DATA_DIR` (`central-config.ts:144-156`): early-return hardcodes sqlite path AND skips the entire `.civicrc` load/merge (drops `auth` + all other config)
+- [x] CLI login token (`login.ts:163-177` / `auth.ts:80-95`): never writes `~/.civicpress/token` that `resolveToken` reads (`auth-utils.ts:31-38`); human mode never prints the token either
+- [x] geography `/linked-records` (`geography.ts:448-499`, cap L27) loses rows past 1000 + wrong total/totalPages; `/records/:id/raw` (`read-handlers.ts:374`) missing `optionalAuth` → editors always treated as public
+- [x] record-history filter: no-op `.replace('/','/')` substring match (`history.ts:103,263`); CLI `civic history` ignores the record arg entirely (`history.ts:70`). Fix = pathspec-scoped `GitEngine.getHistory` (`git-engine.ts:139`)
+- [x] publishDraft ordering (`publish-draft-saga.ts` steps L552-559): DeleteDraftStep (L402) runs after the irreversible CommitToGitStep (L362, isCompensatable=false) with a log-only no-op compensation (L423) → DB hiccup loses a committed record's draft unrecoverably
+- [x] BB device health-monitor + stale-reaper implemented (`device-connection-tracker.ts:304`/`335`) but never started in production; wire at the tracker factory (`broadcast-box-services.ts:294-310`)
+- [ ] UI: `useMarkdown` heading inline formatting; autosave timer unmount; editor host collab-vs-CM latch at mount (NOT in Batch 4 — UI cluster deferred)
+- [ ] HW multi-output ffmpeg filtergraph pad reuse (`[v_wm]` mapped twice) — lives in the separate BroadcastBox HW repo, not this monorepo batch
 - [x] `.npmrc:29` jammed keys (folded into CI batch — trailing `strict-peer-dependencies=false` never parsed; dropped it, preserving effective config)
-- [ ] Notifications: empty recipient dispatched silently (`notification-service.ts:278-292` returns '', no guard in sendToChannel L262); SMS/Slack config declared (`notification-config.ts:51-66`) but only email channel implemented → "Channel not found" throw if enabled
+- [x] Notifications: empty recipient dispatched silently (`notification-service.ts:278-292` returns '', no guard in sendToChannel L262); SMS/Slack config declared (`notification-config.ts:51-66`) but only email channel implemented → "Channel not found" throw if enabled
 
 ## Tier D — small, batchable
 

--- a/modules/api/src/broadcast-box-bootstrap.ts
+++ b/modules/api/src/broadcast-box-bootstrap.ts
@@ -210,7 +210,8 @@ function resolveOptional<T>(
   }
 }
 
-/** Stop background work — the enrollment-cleanup interval + redaction worker. */
+/** Stop background work — enrollment cleanup, redaction worker, and the
+ * connection tracker's health-monitor/reaper intervals. */
 function stopBroadcastBox(
   container: ReturnType<CivicPress['getContainer']>,
   logger: Logger
@@ -218,6 +219,7 @@ function stopBroadcastBox(
   for (const key of [
     'broadcastBoxEnrollmentCleanup',
     'broadcastBoxRedactionWorker',
+    'broadcastBoxConnectionTracker',
   ]) {
     try {
       if (container.isRegistered(key)) {

--- a/modules/api/src/routes/geography.ts
+++ b/modules/api/src/routes/geography.ts
@@ -462,18 +462,34 @@ export function createGeographyRouter(
         const page = (req.query.page as unknown as number) || 1;
         const limit = (req.query.limit as unknown as number) || 50;
 
-        // FA-API-014: reuse the shared RecordsService (injected) instead of
-        // constructing one per request, and page the response. The scan stays
-        // bounded by LINKED_RECORDS_SCAN_CAP so a single request can't pull the
-        // whole corpus into memory.
-        const allRecords = await recordsService.listRecords({
-          limit: LINKED_RECORDS_SCAN_CAP,
-        });
-        const linked = allRecords.records.filter((record) => {
-          const links = (record as { linkedGeographyFiles?: Array<{ id: string }> })
-            .linkedGeographyFiles;
-          return links?.some((link) => link.id === id);
-        });
+        // Scan the WHOLE corpus in bounded batches, keeping only the records
+        // that link this geography. The prior implementation capped the scan
+        // at the first 1000 records, silently dropping links on any record
+        // past the cap AND reporting a `total` computed from that truncated
+        // subset. Memory stays proportional to the (small) match set plus one
+        // batch, not the whole corpus (FA-API-014's concern).
+        const linked: unknown[] = [];
+        let scanPage = 1;
+        let scanned = 0;
+        for (;;) {
+          const batch = await recordsService.listRecords({
+            limit: LINKED_RECORDS_SCAN_CAP,
+            page: scanPage,
+          });
+          for (const record of batch.records) {
+            const links = (
+              record as { linkedGeographyFiles?: Array<{ id: string }> }
+            ).linkedGeographyFiles;
+            if (links?.some((link) => link.id === id)) {
+              linked.push(record);
+            }
+          }
+          scanned += batch.records.length;
+          if (batch.records.length === 0 || scanned >= batch.totalCount) {
+            break;
+          }
+          scanPage += 1;
+        }
 
         const total = linked.length;
         const start = (page - 1) * limit;

--- a/modules/api/src/routes/history.ts
+++ b/modules/api/src/routes/history.ts
@@ -5,6 +5,7 @@ import {
   requireRecordPermission,
 } from '../middleware/auth.js';
 import { Logger } from '@civicpress/core';
+import type { GitCommit } from '@civicpress/core';
 import {
   sendSuccess,
   handleApiError,
@@ -13,6 +14,43 @@ import {
 } from '../utils/api-logger.js';
 
 const logger = new Logger();
+
+/**
+ * Return commit history scoped to a single record. Resolves the record's
+ * real file path and uses a git pathspec (`git log -- <path>`); only if the
+ * record can't be resolved does it fall back to a commit-message match
+ * (with the id and `<id>.md`, no no-op replace). No record → full history.
+ */
+async function resolveRecordHistory(
+  req: AuthenticatedRequest,
+  gitEngine: {
+    getHistory: (limit?: number, pathspec?: string) => Promise<GitCommit[]>;
+  },
+  record: string | undefined
+): Promise<GitCommit[]> {
+  if (!record) {
+    return gitEngine.getHistory();
+  }
+  try {
+    const rec = await req.civicPress?.getRecordManager().getRecord(record);
+    const recordPath = (rec as { path?: string } | null | undefined)?.path;
+    if (recordPath) {
+      return gitEngine.getHistory(undefined, recordPath);
+    }
+  } catch (error) {
+    logger.warn('Could not resolve record path for history pathspec', {
+      record,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  // Fallback: message match (id or <id>.md), no no-op replace.
+  const messageNeedle = `${record}.md`;
+  const all = await gitEngine.getHistory();
+  return all.filter(
+    (commit) =>
+      commit.message.includes(record) || commit.message.includes(messageNeedle)
+  );
+}
 
 export function createHistoryRouter() {
   const router = Router();
@@ -88,22 +126,16 @@ export function createHistoryRouter() {
         const historyLimit = parseInt(limit as string) || 10;
         const historyOffset = parseInt(offset as string) || 0;
 
-        // Get all commits first to get accurate total count
-        let history = await gitEngine.getHistory();
-
-        // Filter by record if specified
-        if (record) {
-          const recordPath = `${record}.md`;
-          const recordStr = record as string;
-          history = history.filter((commit) => {
-            // Check if this commit affected the specified record
-            return (
-              commit.message.includes(recordStr) ||
-              commit.message.includes(recordPath) ||
-              commit.message.includes(recordStr.replace('/', '/'))
-            );
-          });
-        }
+        // Scope by record via a git pathspec when one is requested. Resolve
+        // the record's actual file path and let git filter (git log -- path);
+        // fall back to a commit-message match only when the record can't be
+        // resolved. (The old code substring-matched the message with a no-op
+        // `.replace('/','/')`, which both missed and over-matched commits.)
+        let history = await resolveRecordHistory(
+          req,
+          gitEngine,
+          record as string | undefined
+        );
 
         // Filter by author if specified
         if (author) {
@@ -250,19 +282,8 @@ export function createHistoryRouter() {
         const historyLimit = parseInt(limit as string) || 10;
         const historyOffset = parseInt(offset as string) || 0;
 
-        // Get all commits first to get accurate total count
-        let history = await gitEngine.getHistory();
-
-        // Filter by specific record
-        const recordPath = `${record}.md`;
-        history = history.filter((commit) => {
-          // Check if this commit affected the specified record
-          return (
-            commit.message.includes(record) ||
-            commit.message.includes(recordPath) ||
-            commit.message.includes(record.replace('/', '/'))
-          );
-        });
+        // Scope by record via a git pathspec (see the list handler above).
+        let history = await resolveRecordHistory(req, gitEngine, record);
 
         // Filter by author if specified
         if (author) {

--- a/modules/api/src/routes/records/read-handlers.ts
+++ b/modules/api/src/routes/records/read-handlers.ts
@@ -373,6 +373,11 @@ export function registerReadRoutes(
   // GET /api/records/:id/raw - Get raw file content for a record (including frontmatter)
   router.get(
     '/:id/raw',
+    // optionalAuth populates req.user for a valid token — without it (the
+    // sibling GET routes all have it) an authenticated editor was always
+    // treated as public here and could not fetch their own draft's raw
+    // content.
+    optionalAuth(recordsService.getCivicPress()),
     param('id').isString().notEmpty(),
     async (req: Request, res: Response) => {
       const isAuthenticated = req.user !== undefined;

--- a/modules/broadcast-box/src/broadcast-box-services.ts
+++ b/modules/broadcast-box/src/broadcast-box-services.ts
@@ -309,6 +309,25 @@ export async function registerBroadcastBoxServices(
     }
   );
 
+  // Start the connection tracker's health monitor + stale-connection reaper.
+  // The singleton is lazy, so resolve it here to bring it (and its timers)
+  // to life; without this a device that dropped uncleanly stayed
+  // connected=true and blocked new sessions. stopBroadcastBox() stops it.
+  try {
+    const tracker = container.resolve<DeviceConnectionTracker>(
+      'broadcastBoxConnectionTracker'
+    );
+    tracker.start();
+    logger.info('Device connection tracker started (health monitor + reaper)', {
+      operation: 'broadcast-box:connection:tracker:started',
+    });
+  } catch (error) {
+    logger.warn('Failed to start device connection tracker', {
+      operation: 'broadcast-box:connection:tracker:start',
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   // Register ProtocolHandler as singleton
   container.singleton('broadcastBoxProtocol', (c: ServiceContainer) => {
     const logger = c.resolve<Logger>('logger');

--- a/modules/broadcast-box/src/services/device-connection-tracker.ts
+++ b/modules/broadcast-box/src/services/device-connection-tracker.ts
@@ -296,6 +296,43 @@ export class DeviceConnectionTracker {
   }
 
   private healthMonitorInterval: ReturnType<typeof setInterval> | null = null;
+  private staleReaperInterval: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Start BOTH the health monitor and the stale-connection reaper. These were
+   * implemented but never wired, so a device that dropped without a clean
+   * disconnect stayed `connected=true` forever — blocking new sessions on
+   * that device. Pair with stop() at shutdown (the timers are not unref'd).
+   */
+  start(
+    healthIntervalMs = 15000,
+    reapIntervalMs = 60000,
+    staleTimeoutMs = 90000
+  ): void {
+    this.startHealthMonitor(healthIntervalMs);
+    this.stopStaleReaper();
+    this.staleReaperInterval = setInterval(() => {
+      void this.cleanupStaleConnections(staleTimeoutMs).catch((error) => {
+        coreWarn('Stale-connection reaper failed', {
+          operation: 'broadcast-box:connection:reaper',
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }, reapIntervalMs);
+  }
+
+  /** Stop both periodic tasks. */
+  stop(): void {
+    this.stopHealthMonitor();
+    this.stopStaleReaper();
+  }
+
+  private stopStaleReaper(): void {
+    if (this.staleReaperInterval) {
+      clearInterval(this.staleReaperInterval);
+      this.staleReaperInterval = null;
+    }
+  }
 
   /**
    * Start periodic health monitoring.

--- a/modules/storage/src/__tests__/circuit-breaker.test.ts
+++ b/modules/storage/src/__tests__/circuit-breaker.test.ts
@@ -45,6 +45,25 @@ describe('CircuitBreaker', () => {
       expect(circuitBreaker.getFailureCount()).toBe(5);
     });
 
+    it('does NOT count isExpectedError throws toward the threshold', async () => {
+      // Post-audit Tier-C: an absent-object read (404) throws but is not a
+      // provider fault — many missing-object reads must not trip the breaker
+      // OPEN against a healthy provider.
+      const notFound = Object.assign(new Error('absent'), { statusCode: 404 });
+      const op = vi.fn().mockRejectedValue(notFound);
+      const isExpected = (e: unknown) =>
+        (e as { statusCode?: number })?.statusCode === 404;
+
+      for (let i = 0; i < 10; i++) {
+        await expect(circuitBreaker.execute(op, isExpected)).rejects.toBe(
+          notFound
+        );
+      }
+
+      expect(circuitBreaker.getState()).toBe('closed');
+      expect(circuitBreaker.getFailureCount()).toBe(0);
+    });
+
     it('should block operations when open', async () => {
       // Open the circuit
       const operation = vi.fn().mockRejectedValue(new Error('Failure'));

--- a/modules/storage/src/__tests__/failover-manager.test.ts
+++ b/modules/storage/src/__tests__/failover-manager.test.ts
@@ -148,6 +148,32 @@ describe('StorageFailoverManager', () => {
       expect(health?.healthy).toBe(true);
     });
 
+    it('fails over on a 404 WITHOUT marking the provider unhealthy (object-absent, not down)', async () => {
+      // Post-audit Tier-C: a provider that lacks the object must fail over to
+      // one that has it, but a 404 is not a health fault — the provider
+      // responded fine, so it must stay eligible for other objects.
+      const notFound = Object.assign(new Error('not on primary'), {
+        statusCode: 404,
+      });
+      const operation = vi.fn().mockImplementation((provider: string) => {
+        if (provider === 'primary') {
+          return Promise.reject(notFound);
+        }
+        return Promise.resolve('found-on-backup');
+      });
+
+      const result = await failoverManager.executeWithFailover(
+        operation,
+        'download'
+      );
+
+      expect(result).toBe('found-on-backup');
+      expect(operation).toHaveBeenCalledWith('primary');
+      expect(operation).toHaveBeenCalledWith('backup1');
+      // Primary must remain healthy — it was up, the object just wasn't there.
+      expect(failoverManager.getProviderHealth('primary')?.healthy).toBe(true);
+    });
+
     it('should skip unhealthy providers', async () => {
       // First, mark primary as unhealthy
       const operation1 = vi.fn().mockImplementation((provider: string) => {

--- a/modules/storage/src/circuit-breaker/circuit-breaker.ts
+++ b/modules/storage/src/circuit-breaker/circuit-breaker.ts
@@ -44,9 +44,18 @@ export class CircuitBreaker {
   }
 
   /**
-   * Execute operation with circuit breaker protection
+   * Execute operation with circuit breaker protection.
+   *
+   * `isExpectedError` marks an error as NOT a provider fault — it rethrows
+   * (so the caller still sees it) but does not count toward the failure
+   * threshold. A storage read that finds the object ABSENT (404) is the
+   * motivating case: the provider responded fine, so five missing-object
+   * reads must not trip the breaker OPEN and knock a healthy provider out.
    */
-  async execute<T>(operation: () => Promise<T>): Promise<T> {
+  async execute<T>(
+    operation: () => Promise<T>,
+    isExpectedError?: (error: unknown) => boolean
+  ): Promise<T> {
     // Check if circuit should transition from open to half-open
     if (this.state === 'open') {
       if (this.shouldAttemptHalfOpen()) {
@@ -76,6 +85,11 @@ export class CircuitBreaker {
       this.onSuccess();
       return result;
     } catch (error) {
+      // An expected error (e.g. object-not-found) is not a provider fault —
+      // rethrow without counting it against the breaker.
+      if (isExpectedError?.(error)) {
+        throw error;
+      }
       // Failure - handle based on state
       this.onFailure();
       throw error;

--- a/modules/storage/src/cloud-uuid-storage/download-ops.ts
+++ b/modules/storage/src/cloud-uuid-storage/download-ops.ts
@@ -90,10 +90,16 @@ export class DownloadOps {
         const executeWithTimeout = () =>
           withTimeout(executeDownload, timeout, 'download');
 
-        // Apply circuit breaker if configured
+        // Apply circuit breaker if configured. A 404 (object absent on this
+        // provider) is NOT a provider fault — exempt it so repeated
+        // missing-object reads don't trip the breaker OPEN against a healthy
+        // provider (the same reasoning the failover manager applies).
+        const isNotFound = (err: unknown) =>
+          err instanceof StorageFileNotFoundError ||
+          (err as { statusCode?: number })?.statusCode === 404;
         if (host.circuitBreakerManager) {
           const breaker = host.circuitBreakerManager.getBreaker(providerName);
-          return breaker.execute(executeWithTimeout);
+          return breaker.execute(executeWithTimeout, isNotFound);
         }
 
         return executeWithTimeout();
@@ -263,7 +269,13 @@ export class DownloadOps {
       const downloadResponse = await blockBlobClient.download();
 
       if (!downloadResponse.readableStreamBody) {
-        return null;
+        // Empty body ~ absent on Azure — throw (not null) so failover
+        // proceeds, consistent with local/S3/GCS.
+        throw new StorageFileNotFoundError(file.id, {
+          folder: file.folder,
+          provider: 'azure',
+          path: file.provider_path,
+        });
       }
 
       // Convert stream to buffer

--- a/modules/storage/src/cloud-uuid-storage/download-ops.ts
+++ b/modules/storage/src/cloud-uuid-storage/download-ops.ts
@@ -14,6 +14,7 @@ import {
   getTimeoutForOperation,
 } from '../utils/timeout.js';
 import { dbRecordToStorageFile } from './internals.js';
+import { StorageFileNotFoundError } from '../errors/storage-errors.js';
 import type { CloudUuidStorageService } from '../cloud-uuid-storage-service.js';
 
 export interface DownloadOpsDeps {
@@ -155,10 +156,15 @@ export class DownloadOps {
   private async getFileContentFromLocal(
     file: StorageFile
   ): Promise<Buffer | null> {
-    const host = this.deps.host;
     if (!(await fs.pathExists(file.provider_path))) {
-      host.logger.error(`File not found on disk: ${file.provider_path}`);
-      return null;
+      // Absent on THIS provider — throw (not return null) so failover tries
+      // the next provider. Returning null read as "success" to the failover
+      // manager, so it never failed over to a provider holding the object.
+      throw new StorageFileNotFoundError(file.id, {
+        folder: file.folder,
+        provider: 'local',
+        path: file.provider_path,
+      });
     }
 
     return await fs.readFile(file.provider_path);
@@ -189,7 +195,12 @@ export class DownloadOps {
       const response = await host.s3Client!.send(command);
 
       if (!response.Body) {
-        return null;
+        // Absent/empty on S3 — throw so failover proceeds (see local).
+        throw new StorageFileNotFoundError(file.id, {
+          folder: file.folder,
+          provider: 's3',
+          path: file.provider_path,
+        });
       }
 
       // Convert stream to buffer (AWS SDK v3)
@@ -276,12 +287,10 @@ export class DownloadOps {
       return host.retryManager.withRetry(downloadOperation);
     }
 
-    try {
-      return await downloadOperation();
-    } catch (error) {
-      host.logger.error('Failed to download from Azure:', error);
-      return null;
-    }
+    // Let errors propagate — the failover manager (and getFileContent's
+    // top-level catch) decide the outcome. Swallowing to null here defeated
+    // failover, the same bug as the provider absence-returns.
+    return await downloadOperation();
   }
 
   /**
@@ -305,7 +314,12 @@ export class DownloadOps {
       // Check if file exists
       const [exists] = await gcsFile.exists();
       if (!exists) {
-        return null;
+        // Absent on GCS — throw so failover proceeds (see local).
+        throw new StorageFileNotFoundError(file.id, {
+          folder: file.folder,
+          provider: 'gcs',
+          path: file.provider_path,
+        });
       }
 
       // Download file content
@@ -318,12 +332,8 @@ export class DownloadOps {
       return host.retryManager.withRetry(downloadOperation);
     }
 
-    try {
-      return await downloadOperation();
-    } catch (error) {
-      host.logger.error('Failed to download from GCS:', error);
-      return null;
-    }
+    // Let errors propagate (see Azure) — swallowing to null defeated failover.
+    return await downloadOperation();
   }
 
   /**

--- a/modules/storage/src/cloud-uuid-storage/file-mgmt-ops.ts
+++ b/modules/storage/src/cloud-uuid-storage/file-mgmt-ops.ts
@@ -283,7 +283,19 @@ export class FileMgmtOps {
         throw new Error('Database service not initialized');
       }
 
-      return await host.databaseService.updateStorageFile(id, updates);
+      const updated = await host.databaseService.updateStorageFile(id, updates);
+
+      // Invalidate the folder cache — a cached listing still holds the old
+      // metadata otherwise (deleteFile + uploadFile already do this; this
+      // path silently didn't, which is what the dead invalidateFile was for).
+      if (updated && host.cacheAdapter) {
+        const file = await host.getFileById(id);
+        if (file) {
+          await host.cacheAdapter.invalidateFolder(file.folder);
+        }
+      }
+
+      return updated;
     } catch (error) {
       host.logger.error('Failed to update file:', error);
       return false;

--- a/modules/storage/src/cloud-uuid-storage/streaming-ops.ts
+++ b/modules/storage/src/cloud-uuid-storage/streaming-ops.ts
@@ -139,34 +139,41 @@ export class StreamingOps {
         sourceStream = fs.createReadStream(request.filePath as string);
       }
 
-      // Count bytes as they flow to the provider. Streaming uploads without a
-      // Content-Length used to persist size=0 for S3/Azure ("provider will set
-      // size" — it never did), which silently broke quota accounting. The
-      // counter is an in-band Transform (NOT a 'data' listener, which would
-      // be a second consumer racing the provider's pipe) so it observes every
-      // byte exactly once and passes each chunk straight through.
-      let byteCount = 0;
-      const counter = new Transform({
-        transform(chunk: Buffer, _enc, cb) {
-          byteCount += chunk.length;
-          cb(null, chunk);
-        },
-      });
-      const countedStream = sourceStream.pipe(counter);
-      // .pipe() does not forward source errors; without this a source-stream
-      // error would leave the provider pipe hanging (the exact hazard the
-      // pre-existing code guarded against by passing the source directly).
-      sourceStream.on('error', (err) => counter.destroy(err));
+      // For REMOTE providers, count bytes as they flow so the DB row records
+      // the real size — streamed S3/Azure uploads without a Content-Length
+      // used to persist size=0 ("provider will set size" — it never did),
+      // silently breaking quota. The counter is an in-band Transform (not a
+      // 'data' listener, which would be a second consumer racing the pipe).
+      // The LOCAL path deliberately does NOT use the counter: its size comes
+      // from an authoritative fs.stat, and inserting a second pipe stage
+      // there only added a stream-error-propagation hazard for no benefit.
+      const makeCountedStream = (): {
+        stream: Readable;
+        getSize: () => number;
+      } => {
+        let byteCount = 0;
+        const counter = new Transform({
+          transform(chunk: Buffer, _enc, cb) {
+            byteCount += chunk.length;
+            cb(null, chunk);
+          },
+        });
+        const piped = sourceStream!.pipe(counter);
+        // .pipe() doesn't forward source errors — destroy the counter so the
+        // provider's consumption rejects instead of hanging.
+        sourceStream!.once('error', (err) => counter.destroy(err));
+        return { stream: piped, getSize: () => byteCount };
+      };
 
       try {
         // Upload to provider using stream
         switch (provider.type) {
           case 'local': {
             providerPath = await this.uploadStreamToLocal(
-              countedStream,
+              sourceStream,
               relativePath
             );
-            // Prefer the on-disk size (authoritative); fall back to the count.
+            // Authoritative on-disk size.
             const fullPath = path.join(
               getLocalStoragePath(host),
               relativePath
@@ -175,9 +182,10 @@ export class StreamingOps {
             actualSize = stats.size;
             break;
           }
-          case 's3':
+          case 's3': {
+            const counted = makeCountedStream();
             providerPath = await this.uploadStreamToS3(
-              countedStream,
+              counted.stream,
               relativePath,
               provider,
               request.contentType ||
@@ -185,11 +193,13 @@ export class StreamingOps {
                 'application/octet-stream',
               request.options?.metadata
             );
-            actualSize = byteCount;
+            actualSize = counted.getSize();
             break;
-          case 'azure':
+          }
+          case 'azure': {
+            const counted = makeCountedStream();
             providerPath = await this.uploadStreamToAzure(
-              countedStream,
+              counted.stream,
               relativePath,
               provider,
               request.contentType ||
@@ -197,11 +207,13 @@ export class StreamingOps {
                 'application/octet-stream',
               request.options?.metadata
             );
-            actualSize = byteCount;
+            actualSize = counted.getSize();
             break;
-          case 'gcs':
+          }
+          case 'gcs': {
+            const counted = makeCountedStream();
             providerPath = await this.uploadStreamToGCS(
-              countedStream,
+              counted.stream,
               relativePath,
               provider,
               request.contentType ||
@@ -209,8 +221,9 @@ export class StreamingOps {
                 'application/octet-stream',
               request.options?.metadata
             );
-            actualSize = byteCount;
+            actualSize = counted.getSize();
             break;
+          }
           default:
             throw new Error(`Unsupported provider type: ${provider.type}`);
         }
@@ -225,7 +238,7 @@ export class StreamingOps {
               : 'UNKNOWN_ERROR';
           host.metricsCollector.recordUpload(
             false,
-            byteCount || request.size || 0,
+            request.size || 0,
             Date.now() - startTime,
             activeProvider,
             errorCode

--- a/modules/storage/src/cloud-uuid-storage/streaming-ops.ts
+++ b/modules/storage/src/cloud-uuid-storage/streaming-ops.ts
@@ -11,7 +11,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import mime from 'mime-types';
 import { v4 as uuidv4 } from 'uuid';
-import { Readable } from 'stream';
+import { Readable, Transform } from 'stream';
 import { pipeline as streamPipeline } from 'node:stream/promises';
 import { loadAwsS3Sdk } from './sdk-loader.js';
 import type {
@@ -132,51 +132,115 @@ export class StreamingOps {
 
       let providerPath: string;
       let actualSize = request.size || 0;
+      const startTime = Date.now();
 
       // Validation + quota have passed — now (and only now) open the source.
       if (!sourceStream) {
         sourceStream = fs.createReadStream(request.filePath as string);
       }
 
-      // Upload to provider using stream
-      switch (provider.type) {
-        case 'local': {
-          providerPath = await this.uploadStreamToLocal(
-            sourceStream,
-            relativePath
-          );
-          // Get actual file size
-          const fullPath = path.join(getLocalStoragePath(host), relativePath);
-          const stats = await fs.stat(fullPath);
-          actualSize = stats.size;
-          break;
+      // Count bytes as they flow to the provider. Streaming uploads without a
+      // Content-Length used to persist size=0 for S3/Azure ("provider will set
+      // size" — it never did), which silently broke quota accounting. The
+      // counter is an in-band Transform (NOT a 'data' listener, which would
+      // be a second consumer racing the provider's pipe) so it observes every
+      // byte exactly once and passes each chunk straight through.
+      let byteCount = 0;
+      const counter = new Transform({
+        transform(chunk: Buffer, _enc, cb) {
+          byteCount += chunk.length;
+          cb(null, chunk);
+        },
+      });
+      const countedStream = sourceStream.pipe(counter);
+      // .pipe() does not forward source errors; without this a source-stream
+      // error would leave the provider pipe hanging (the exact hazard the
+      // pre-existing code guarded against by passing the source directly).
+      sourceStream.on('error', (err) => counter.destroy(err));
+
+      try {
+        // Upload to provider using stream
+        switch (provider.type) {
+          case 'local': {
+            providerPath = await this.uploadStreamToLocal(
+              countedStream,
+              relativePath
+            );
+            // Prefer the on-disk size (authoritative); fall back to the count.
+            const fullPath = path.join(
+              getLocalStoragePath(host),
+              relativePath
+            );
+            const stats = await fs.stat(fullPath);
+            actualSize = stats.size;
+            break;
+          }
+          case 's3':
+            providerPath = await this.uploadStreamToS3(
+              countedStream,
+              relativePath,
+              provider,
+              request.contentType ||
+                mime.lookup(request.filename) ||
+                'application/octet-stream',
+              request.options?.metadata
+            );
+            actualSize = byteCount;
+            break;
+          case 'azure':
+            providerPath = await this.uploadStreamToAzure(
+              countedStream,
+              relativePath,
+              provider,
+              request.contentType ||
+                mime.lookup(request.filename) ||
+                'application/octet-stream',
+              request.options?.metadata
+            );
+            actualSize = byteCount;
+            break;
+          case 'gcs':
+            providerPath = await this.uploadStreamToGCS(
+              countedStream,
+              relativePath,
+              provider,
+              request.contentType ||
+                mime.lookup(request.filename) ||
+                'application/octet-stream',
+              request.options?.metadata
+            );
+            actualSize = byteCount;
+            break;
+          default:
+            throw new Error(`Unsupported provider type: ${provider.type}`);
         }
-        case 's3':
-          providerPath = await this.uploadStreamToS3(
-            sourceStream,
-            relativePath,
-            provider,
-            request.contentType ||
-              mime.lookup(request.filename) ||
-              'application/octet-stream',
-            request.options?.metadata
+      } catch (uploadErr) {
+        // Record the failure in the same metrics the buffer path uses — the
+        // streaming path previously reported nothing.
+        if (host.metricsCollector) {
+          const errorCode =
+            uploadErr instanceof Error &&
+            (uploadErr as Error & { code?: string }).code
+              ? (uploadErr as Error & { code?: string }).code
+              : 'UNKNOWN_ERROR';
+          host.metricsCollector.recordUpload(
+            false,
+            byteCount || request.size || 0,
+            Date.now() - startTime,
+            activeProvider,
+            errorCode
           );
-          actualSize = request.size || 0; // S3 will set size
-          break;
-        case 'azure':
-          providerPath = await this.uploadStreamToAzure(
-            sourceStream,
-            relativePath,
-            provider,
-            request.contentType ||
-              mime.lookup(request.filename) ||
-              'application/octet-stream',
-            request.options?.metadata
-          );
-          actualSize = request.size || 0; // Azure will set size
-          break;
-        default:
-          throw new Error(`Unsupported provider type: ${provider.type}`);
+        }
+        throw uploadErr;
+      }
+
+      if (host.metricsCollector) {
+        host.metricsCollector.recordUpload(
+          true,
+          actualSize,
+          Date.now() - startTime,
+          activeProvider
+        );
       }
 
       // Create storage file record
@@ -419,6 +483,44 @@ export class StreamingOps {
     });
 
     return `azure://${provider.account_name}/${provider.container_name}/${blobName}`;
+  }
+
+  /**
+   * Upload stream to Google Cloud Storage. The buffer path supported GCS but
+   * the streaming switch omitted it, so any GCS deployment threw "Unsupported
+   * provider type" on every streamed upload.
+   */
+  private async uploadStreamToGCS(
+    stream: Readable,
+    relativePath: string,
+    provider: StorageProvider,
+    contentType: string,
+    metadata?: Record<string, string>
+  ): Promise<string> {
+    const host = this.deps.host;
+    if (!host.gcsBucket) {
+      throw new Error('GCS bucket not initialized');
+    }
+
+    const fileName = provider.prefix
+      ? `${provider.prefix}/${relativePath}`
+      : relativePath;
+
+    const gcsFile = host.gcsBucket.file(fileName);
+    const writeStream = gcsFile.createWriteStream({
+      resumable: false,
+      metadata: {
+        contentType,
+        metadata: {
+          originalName: path.basename(relativePath),
+          uploadedAt: new Date().toISOString(),
+          ...metadata,
+        },
+      },
+    });
+    await streamPipeline(stream, writeStream);
+
+    return `gs://${provider.bucket}/${fileName}`;
   }
 
   /**

--- a/modules/storage/src/failover/storage-failover-manager.ts
+++ b/modules/storage/src/failover/storage-failover-manager.ts
@@ -120,8 +120,15 @@ export class StorageFailoverManager {
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
-        // Mark provider as unhealthy
-        this.markProviderUnhealthy(provider, lastError);
+        // A 404 means the provider responded fine — the OBJECT just isn't on
+        // it. That is NOT a health problem, so don't penalize the provider
+        // (it must stay eligible for other objects); still try the next
+        // provider, because a failover replica may hold the object. Any
+        // other error is a real provider fault → mark unhealthy.
+        const statusCode = (error as { statusCode?: number })?.statusCode;
+        if (statusCode !== 404) {
+          this.markProviderUnhealthy(provider, lastError);
+        }
 
         // Log failover attempt
         this.logger.warn(
@@ -130,6 +137,7 @@ export class StorageFailoverManager {
             provider,
             operation: operationName,
             error: lastError.message,
+            objectNotFound: statusCode === 404,
           }
         );
 

--- a/tests/api/history.test.ts
+++ b/tests/api/history.test.ts
@@ -52,6 +52,7 @@ describe('History API', () => {
       expect(response.body.data.history).toBeDefined();
     });
 
+
     it('should support pagination', async () => {
       const response = await request(context.api.getApp())
         .get('/api/v1/history?limit=5&offset=0')

--- a/tests/api/records-raw-authz.test.ts
+++ b/tests/api/records-raw-authz.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import {
+  createAPITestContext,
+  cleanupAPITestContext,
+  APITestContext,
+} from '../fixtures/test-setup';
+
+/**
+ * Post-audit Tier-C: GET /api/v1/records/:id/raw was registered WITHOUT the
+ * optionalAuth middleware its sibling GET routes all use, so req.user was
+ * never populated — an authenticated editor was always treated as public
+ * and could not fetch their own unpublished draft's raw content.
+ */
+describe('GET /api/v1/records/:id/raw — authz', () => {
+  let context: APITestContext;
+  let adminToken: string;
+
+  beforeEach(async () => {
+    context = await createAPITestContext();
+    const adminResponse = await request(context.api.getApp())
+      .post('/api/v1/auth/simulated')
+      .send({ username: 'admin', role: 'admin' });
+    adminToken = adminResponse.body.data.session.token;
+  });
+
+  afterEach(async () => {
+    await cleanupAPITestContext(context);
+  });
+
+  it('lets an authenticated editor read an unpublished draft; a public caller gets 404', async () => {
+    // POST /records creates an unpublished DRAFT (not a published record).
+    const created = await request(context.api.getApp())
+      .post('/api/v1/records')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        type: 'policy',
+        title: 'Draft Raw Authz',
+        content: '# Draft Raw Authz\n\nSecret draft body.',
+      });
+    expect(created.status).toBe(201);
+    const id = created.body.data.id;
+
+    // Authenticated editor: optionalAuth populates req.user → draft is served.
+    const authed = await request(context.api.getApp())
+      .get(`/api/v1/records/${id}/raw`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(authed.status).toBe(200);
+
+    // Public caller: the draft is not published → 404 (unchanged, correct).
+    const anon = await request(context.api.getApp()).get(
+      `/api/v1/records/${id}/raw`
+    );
+    expect(anon.status).toBe(404);
+  });
+});

--- a/tests/core/config-discovery.test.ts
+++ b/tests/core/config-discovery.test.ts
@@ -185,7 +185,7 @@ describe('Config Discovery with Database Configuration', () => {
   });
 
   describe('Configuration file precedence', () => {
-    it('should prioritize .civicrc over environment variables', async () => {
+    it('CIVIC_DATA_DIR overrides dataDir but does not discard the .civicrc database block', async () => {
       const civicrcPath = join(context.testDir, '.civicrc');
       const civicrc = {
         dataDir: 'data',
@@ -213,11 +213,49 @@ describe('Config Discovery with Database Configuration', () => {
       try {
         const config = CentralConfigManager.getConfig();
 
-        // Should use .civicrc configuration, not environment variable
-        // Note: The current implementation prioritizes environment variables
-        // This test documents the expected behavior
-        expect(config.dataDir).toBeDefined();
+        // CIVIC_DATA_DIR overrides the data directory...
+        expect(config.dataDir).toBe('/different/path');
+        // ...but the .civicrc database block is still honored (post-audit
+        // Tier-C: the env var used to early-return a minimal config and drop
+        // the entire .civicrc, hardcoding the DB to <env>/civic.db).
         expect(config.database?.type).toBe('sqlite');
+        expect(config.database?.sqlite?.file).toContain(
+          'data/.civic/civic.db'
+        );
+      } finally {
+        process.chdir(originalCwd);
+        if (originalEnv) {
+          process.env.CIVIC_DATA_DIR = originalEnv;
+        } else {
+          delete process.env.CIVIC_DATA_DIR;
+        }
+      }
+    });
+
+    it('preserves non-database .civicrc fields (e.g. auth) when CIVIC_DATA_DIR is set', async () => {
+      const civicrcPath = join(context.testDir, '.civicrc');
+      const civicrc = {
+        dataDir: 'data',
+        database: { type: 'sqlite', sqlite: { file: 'data/.civic/civic.db' } },
+        auth: { providers: ['password'], defaultRole: 'public' },
+      };
+      writeFileSync(civicrcPath, yaml.dump(civicrc));
+      CentralConfigManager.reset();
+
+      const originalEnv = process.env.CIVIC_DATA_DIR;
+      process.env.CIVIC_DATA_DIR = '/different/path';
+      const originalCwd = process.cwd();
+      process.chdir(context.testDir);
+
+      try {
+        const config = CentralConfigManager.getConfig() as {
+          dataDir?: string;
+          auth?: { providers?: string[]; defaultRole?: string };
+        };
+        expect(config.dataDir).toBe('/different/path');
+        // auth was silently discarded by the old early-return.
+        expect(config.auth?.providers).toEqual(['password']);
+        expect(config.auth?.defaultRole).toBe('public');
       } finally {
         process.chdir(originalCwd);
         if (originalEnv) {

--- a/tests/core/notifications/notification-service-truthful-audit.test.ts
+++ b/tests/core/notifications/notification-service-truthful-audit.test.ts
@@ -117,6 +117,24 @@ describe('NotificationService — truthful audit log (notifications-001)', () =>
     expect(entry.details.template).toBe('test_template');
   });
 
+  it('a notification with NO recipient fails the channel (never silently "sent")', async () => {
+    // Post-audit Tier-C: getChannelRecipient returns '' for a missing
+    // address, and the old sendToChannel dispatched to '' and logged
+    // success. It must fail the channel instead.
+    service.registerChannel('email', makeChannel('success') as any);
+
+    const response = await service.sendNotification({
+      // no `email` field → blank recipient
+      channels: ['email'],
+      template: 'test_template',
+      data: { name: 'Nobody' },
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.failedChannels).toEqual(['email']);
+    expect(response.sentChannels).toEqual([]);
+  });
+
   it('records success: false and action notification_partial_or_failed when the only channel fails', async () => {
     service.registerChannel(
       'email',

--- a/tests/core/role-cycle.test.ts
+++ b/tests/core/role-cycle.test.ts
@@ -76,4 +76,31 @@ describe('Role hierarchy cycle detection', () => {
     // without re-walking admin → clerk forever.
     expect(await authService.userCan(clerk, 'system:admin')).toBe(true);
   });
+
+  it('a node reachable by two paths (public) is NOT flagged as a cycle', async () => {
+    // `public` is reached from admin both directly (admin → public) and via
+    // clerk (admin → clerk → public) — a diamond, not a cycle. A path-based
+    // (not global) visited set must resolve it without a spurious "circular"
+    // warning, even though a REAL cycle (clerk → admin) exists elsewhere in
+    // this fixture. Only the true back-edge should warn.
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.join(' '));
+    };
+    try {
+      const admin = await authService.createUser({
+        username: 'diamondadmin',
+        email: 'diamondadmin@example.com',
+        role: 'admin',
+      });
+      expect(await authService.userCan(admin, 'records:view')).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+    // The diamond node 'public' must never be reported as circular.
+    expect(
+      warnings.some((w) => /Circular role inheritance.*'public'/.test(w))
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Post-audit hardening batch 4 (backlog Tier C — 9 scouted findings). **Stacked on #17** — retarget to `main` after #17 merges.

## Fixes (one thematic commit each)
1. **Storage streaming resilience** — GCS was missing from the stream switch (threw on every GCS streamed upload); S3/Azure streamed uploads persisted `size=0` (broke quota) — now counted in-band; streaming now records metrics. **updateFile** never invalidated the folder cache (stale listings). **Failover-on-read** treated a provider returning "object absent" (null) as success and never failed over — absence now throws `StorageFileNotFoundError` and the failover manager tries the next provider *without* marking a 404'd provider unhealthy.
2. **CIVIC_DATA_DIR** stopped discarding the entire `.civicrc` (auth + custom database block) — it now overrides only `dataDir`. **CLI login** persists its token to `~/.civicpress/token` (0600) where `resolveToken` reads it, and logout revokes + clears it — the login→command loop was broken.
3. **geography `/linked-records`** scanned only the first 1000 records (dropped rows + wrong total) — now a bounded full-corpus scan. **`/records/:id/raw`** was missing `optionalAuth` (editors treated as public). **record history** filtered by a no-op commit-message substring — now a git pathspec on the record's real file (API + CLI).
4. **publishDraft** DeleteDraftStep now snapshots + restores the draft on rollback (was a no-op compensation losing the draft while the commit stood). **BB connection tracker** health-monitor + stale-reaper are now started/stopped (dead devices no longer stay `connected=true`). **Notifications** reject a blank recipient (was silently "sent") and give an honest error for the configurable-but-unimplemented sms/slack channels.

Plus a **Tier-B follow-up**: the role-cycle guard used a global visited-set that flagged a legal DAG *diamond* (the default roles.yml) as a cycle — now path-based, so only true back-edges warn.

## Verification
- New tests: storage failover-404 semantics, CLI token round-trip/precedence/0600, `CIVIC_DATA_DIR`-preserves-`.civicrc`, `/records/:id/raw` editor-vs-public, notification empty-recipient, role-cycle diamond.
- Full storage module suite (225), full BB module suite (178), saga + notifications + config + geography + history + records suites — all green from a clean test DB; lint clean.
- `.bin` executable-deny narrowing already fixed on #17 (that CI failure was a stale run for a superseded commit; #17 tip is green).

## Admin follow-up
Same as prior PRs — status-check-only branch protection; command in #15's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)