### PR TITLE
ci(security): CodeQL SAST + Node/pnpm engines reconcile

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: codeql
+
+# Static analysis (SAST) of the JS/TS code via GitHub CodeQL. Findings surface
+# in Security > Code scanning; the analysis is REPORT-ONLY — the workflow
+# succeeds even when CodeQL raises alerts, so it never gates CI (only
+# build-test + audit-truth-check are required checks). JS/TS needs no
+# compilation, so `build-mode: none` analyzes the source directly — no monorepo
+# build wiring, no dependency install. node_modules and (gitignored) dist are
+# not present in a fresh checkout, so only first-party source is scanned.
+#
+# Runs on PRs to the integration branches (pre-merge signal), on pushes to
+# main (keeps the default-branch baseline current), and weekly.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '27 3 * * 2' # Tuesdays 03:27 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write # upload results to Security > Code scanning
+  actions: read
+
+jobs:
+  analyze:
+    name: analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          category: '/language:javascript-typescript'

--- a/docs/backlog/2026-07-post-audit-hardening.md
+++ b/docs/backlog/2026-07-post-audit-hardening.md
@@ -841,7 +841,19 @@ follow-up. (Storage, config+CLI, API-routes clusters + saga/BB/notifications.)
     DoS is not exploitable in the request surface. Left at the highest safe same-major versions
     (1.1.16 / 2.1.2 / 5.0.8); revisit when the old CJS minimatch consumers age out. The scheduled
     osv-scanner (report-only) will keep it visible.
+- [x] **CodeQL SAST + Node-pin reconcile — DONE 2026-07-30 (finishes the supply-chain bundle).**
+  - **CodeQL** (`.github/workflows/codeql.yml`): SHA-pinned `github/codeql-action` v3, language
+    `javascript-typescript`, `build-mode: none` (JS/TS needs no compile, no dep install; a fresh
+    checkout has no node_modules/dist so only first-party source is scanned). REPORT-ONLY —
+    the analyze step succeeds even with alerts, so it never gates CI (only build-test +
+    audit-truth-check are required). Runs on PRs to main/develop, pushes to main, weekly, and
+    `workflow_dispatch`. Findings land in Security > Code scanning (SARIF, same channel osv-scanner
+    already proved works).
+  - **Node-pin reconcile**: added `engines` to the root `package.json` (`node: ">=22"`,
+    `pnpm: ">=9"`) — previously absent. Now all Node/pnpm pins agree: `.nvmrc` 22.22.3, `.npmrc`
+    `use-node-version=22.22.3`, CI `node-version-file: .nvmrc`, `packageManager pnpm@9.15.9`, and
+    the new `engines` floor. Metadata-only (no `engine-strict`), so it declares the requirement
+    without breaking installs on patch drift.
 - [ ] `ui-003` SSR; signed appliance image;
   HW config-apply/reboot/button; equity/i18n; uncleared-surface follow-up
-  (quick-start/by-meeting authz, FTS injection, config reflection);
-  CodeQL SAST + Node-pin reconcile (remainder of supply-chain); doc-drift sweep
+  (quick-start/by-meeting authz, FTS injection, config reflection); doc-drift sweep

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "CivicPress project",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=9"
+  },
   "scripts": {
     "dev": "concurrently \"pnpm run dev:api\" \"pnpm run dev:ui\"",
     "dev:api": "cd modules/api && pnpm run dev",


### PR DESCRIPTION
## Summary

Small, self-contained CI/security addition (finishes the supply-chain bundle) —
and this PR doubles as the **first live run of the CodeQL workflow**, which
can't be exercised locally or on develop pushes.

## Changes (1 commit, `cc21a2d`)

- **CodeQL SAST** (`.github/workflows/codeql.yml`) — SHA-pinned
  `github/codeql-action` v3, language `javascript-typescript`, `build-mode: none`
  (JS/TS needs no compile or dependency install; a fresh checkout has no
  node_modules/dist, so only first-party source is scanned). **Report-only**: the
  analyze step succeeds even with alerts, so it never gates CI — only
  `build-test` + `audit-truth-check` are required checks. Findings surface in
  Security → Code scanning. Triggers: PRs to main/develop, pushes to main,
  weekly, and `workflow_dispatch`.
- **Node-pin reconcile** — added `engines` to the root `package.json`
  (`node: ">=22"`, `pnpm: ">=9"`), previously absent. All pins now agree:
  `.nvmrc` 22.22.3, `.npmrc use-node-version=22.22.3`, CI `node-version-file:
  .nvmrc`, `packageManager pnpm@9.15.9`. Metadata-only (no `engine-strict`).

## Verification

This PR's checks confirm it: `build-test` + `audit-truth-check` + `osv-scanner`
(unaffected by these changes), **plus `codeql` running for the first time** as a
PR check. Landing it on `main` also activates the scheduled + `workflow_dispatch`
runs. The `engines` addition is metadata-only — no lockfile change, no
dependency install impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
