### PR TITLE
fix(ui): make Settings → Activity log list scrollable (#11)

### DIFF
--- a/modules/ui/app/pages/settings/activity.vue
+++ b/modules/ui/app/pages/settings/activity.vue
@@ -80,43 +80,51 @@
         >
           {{ error }}
         </div>
-        <div v-else class="overflow-auto">
-          <table class="min-w-full text-sm">
-            <thead class="text-left text-gray-600 dark:text-gray-400">
-              <tr>
-                <th class="py-2 pr-4">{{ t('settings.activity.time') }}</th>
-                <th class="py-2 pr-4">{{ t('settings.activity.actor') }}</th>
-                <th class="py-2 pr-4">{{ t('settings.activity.action') }}</th>
-                <th class="py-2 pr-4">{{ t('settings.activity.target') }}</th>
-                <th class="py-2 pr-4">{{ t('settings.activity.outcome') }}</th>
-                <th class="py-2 pr-4">{{ t('settings.activity.message') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="item in items"
-                :key="item.id"
-                class="border-t border-gray-200 dark:border-gray-800"
+        <div v-else>
+          <div class="overflow-auto max-h-[60vh]">
+            <table class="min-w-full text-sm">
+              <thead
+                class="text-left text-gray-600 dark:text-gray-400 sticky top-0 bg-white dark:bg-gray-900"
               >
-                <td class="py-2 pr-4 whitespace-nowrap">
-                  {{ formatTime(item.timestamp) }}
-                </td>
-                <td class="py-2 pr-4">{{ formatActor(item.actor) }}</td>
-                <td class="py-2 pr-4">{{ item.action }}</td>
-                <td class="py-2 pr-4">{{ formatTarget(item.target) }}</td>
-                <td class="py-2 pr-4">
-                  <UBadge
-                    :color="item.outcome === 'success' ? 'primary' : 'error'"
-                    variant="soft"
-                    >{{ item.outcome }}</UBadge
-                  >
-                </td>
-                <td class="py-2 pr-4 truncate max-w-[320px]">
-                  {{ item.message || '' }}
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                <tr>
+                  <th class="py-2 pr-4">{{ t('settings.activity.time') }}</th>
+                  <th class="py-2 pr-4">{{ t('settings.activity.actor') }}</th>
+                  <th class="py-2 pr-4">{{ t('settings.activity.action') }}</th>
+                  <th class="py-2 pr-4">{{ t('settings.activity.target') }}</th>
+                  <th class="py-2 pr-4">
+                    {{ t('settings.activity.outcome') }}
+                  </th>
+                  <th class="py-2 pr-4">
+                    {{ t('settings.activity.message') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="item in items"
+                  :key="item.id"
+                  class="border-t border-gray-200 dark:border-gray-800"
+                >
+                  <td class="py-2 pr-4 whitespace-nowrap">
+                    {{ formatTime(item.timestamp) }}
+                  </td>
+                  <td class="py-2 pr-4">{{ formatActor(item.actor) }}</td>
+                  <td class="py-2 pr-4">{{ item.action }}</td>
+                  <td class="py-2 pr-4">{{ formatTarget(item.target) }}</td>
+                  <td class="py-2 pr-4">
+                    <UBadge
+                      :color="item.outcome === 'success' ? 'primary' : 'error'"
+                      variant="soft"
+                      >{{ item.outcome }}</UBadge
+                    >
+                  </td>
+                  <td class="py-2 pr-4 truncate max-w-[320px]">
+                    {{ item.message || '' }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <div class="flex items-center justify-between py-3">
             <UButton :disabled="page <= 0" @click="prevPage" variant="ghost">{{
               t('common.previous')
@@ -209,7 +217,9 @@ const load = async (goTo?: number) => {
       throw new Error('Unexpected response');
     }
   } catch (e: unknown) {
-    error.value = (e instanceof Error ? e.message : '') || t('settings.activity.failedToLoad');
+    error.value =
+      (e instanceof Error ? e.message : '') ||
+      t('settings.activity.failedToLoad');
   } finally {
     loading.value = false;
   }
@@ -217,7 +227,10 @@ const load = async (goTo?: number) => {
 
 const formatTime = (ts: string) => new Date(ts).toLocaleString();
 const formatActor = (
-  a: { username?: string; id?: string | number; role?: string } | null | undefined
+  a:
+    | { username?: string; id?: string | number; role?: string }
+    | null
+    | undefined
 ) => (a ? `${a.username || a.id || ''}${a.role ? ` (${a.role})` : ''}` : '');
 const formatTarget = (
   t: { type?: string; id?: string | number } | null | undefined


### PR DESCRIPTION
## Summary

Fixes #11 — the activity log list on **Settings → Activity** did not scroll, so with more than ~10–15 entries the list was clipped at the bottom of the page and older entries were unreachable.

## Root cause

The table was wrapped in a single unbounded `overflow-auto` container (which also held the pagination bar). With no height constraint, the container just grew and was clipped by the dashboard panel body — neither the page nor the container ever scrolled.

## Fix

- Bound the table in a `max-h-[60vh] overflow-auto` scroll area so it scrolls internally regardless of the dashboard panel's own overflow handling.
- Make the header row `sticky top-0` (with a solid background) so column labels stay visible while scrolling.
- Move the pagination controls **outside** the scroll region so they remain visible at the bottom.

Scope is a single file: `modules/ui/app/pages/settings/activity.vue`. Pure template/CSS — no script or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)