### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,14 +43,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build the UI's workspace dependencies
-        # `^...` = only the dependencies of @civicpress/ui (editor-schema, …),
-        # not the UI itself — the dev server builds the UI on the fly.
-        run: pnpm --filter "@civicpress/ui^..." run build
+      - name: Build the UI (and its workspace deps)
+        # `...` = @civicpress/ui plus its deps (editor-schema, …). CI serves the
+        # built preview below rather than the dev server, which cold-starts too
+        # slowly on a runner (the dev server is the local default).
+        run: pnpm --filter "@civicpress/ui..." run build
 
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run browser e2e
-        # Playwright's webServer auto-starts the Nuxt dev server and waits for it.
+        # Playwright's webServer serves the built UI preview and waits for it.
         run: pnpm e2e
+        env:
+          CIVIC_E2E_WEBSERVER: pnpm --filter @civicpress/ui run preview

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,56 @@
+# Browser end-to-end tests (Playwright + Chromium) against the real UI SPA.
+#
+# Separate from the `ci` job because it needs a browser and a running UI server.
+# The API is stubbed at the network boundary inside the specs (page.route), so no
+# database/API boot is required — this layer verifies real-browser routing,
+# hydration, and rendering that the vitest component tests and the API-level
+# journey tests (tests/e2e/) can't reach.
+#
+# The UI's workspace deps (e.g. @civicpress/editor-schema) are consumed as dist,
+# so they must be built before the Nuxt dev server (which Playwright auto-starts
+# via webServer) can resolve them. Action refs are SHA-pinned to match ci.yml.
+name: browser-e2e
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  browser-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the UI's workspace dependencies
+        # `^...` = only the dependencies of @civicpress/ui (editor-schema, …),
+        # not the UI itself — the dev server builds the UI on the fly.
+        run: pnpm --filter "@civicpress/ui^..." run build
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run browser e2e
+        # Playwright's webServer auto-starts the Nuxt dev server and waits for it.
+        run: pnpm e2e

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ Icon?
 
 # BroadcastBox live-e2e harness throwaway data
 /.e2e-live/
+
+# Playwright browser-e2e artifacts
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-04
+
+<!-- markdownlint-disable MD024 -->
+
+Completes the **v0.3.x — Editor, Attachments & Civic UX** milestone. The feature
+work (rich editor, drag-and-drop attachments, i18n/equity, spec-reality gate)
+shipped in 0.2.1; this release adds the remaining test and documentation
+completion, so the milestone's exit criteria are genuinely met.
+
+### Added
+
+- **Browser end-to-end tests (Playwright + Chromium).** A real-browser layer
+  that drives the actual Nuxt UI SPA with the API stubbed at the network
+  boundary — smoke journeys (the app boots + hydrates, the records browser
+  renders a record from the API, the login form renders), plus a SHA-pinned
+  `browser-e2e` CI workflow. Run with `pnpm e2e`. Fills the gap the vitest
+  component tests and the API-level journey tests couldn't reach.
+- **Live cloud-storage integration test.** Exercises the real S3 upload →
+  download → delete round-trip against a live S3-compatible server (minio),
+  closing the "no live-cloud test" gap behind the mocked SDK boundary. Opt-in
+  via `CIVIC_TEST_LIVE_S3=1`; skips otherwise so normal CI stays hermetic.
+- **Spec-frontmatter CI guard.** `pnpm specs:check` (and a vitest gate) asserts
+  every spec's frontmatter parses and declares a known status.
+
+### Changed
+
+- **Normalized spec metadata into real top-of-file YAML frontmatter** across 68
+  specs. They carried a malformed, jammed single-line block after the title (an
+  artifact of prettier prose-wrapping metadata that was never real frontmatter);
+  they now use proper frontmatter (version / status / created / updated) with
+  the AI-authored boilerplate dropped. `spec:validate` is now frontmatter-aware.
+  This completes the "every spec matches implementation reality" gate.
+
 ## [0.2.1] - 2026-08-03
 
 <!-- markdownlint-disable MD024 -->

--- a/docs/specs/accessibility.md
+++ b/docs/specs/accessibility.md
@@ -1,3 +1,10 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `accessibility.md`
 
 > **Implementation status (2026-08-03).** This spec describes a **target**
@@ -6,26 +13,6 @@
 > localizing interactive `aria-label`s so screen readers follow the UI locale).
 > Treat the compliance claims below as goals, not shipped guarantees.
 > Authoritative status: `docs/project-status.md`.
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive accessibility documentation
-- WCAG compliance
-- testing patterns
-- security considerations
-- automated testing frameworks compatibility: min_civicpress: 1.0.0
- max_civicpress: 'null' dependencies:
- - 'ui.md: >=1.0.0'
- - 'themes.md: >=1.0.0'
- - 'translations.md: >=1.0.0' authors:
-- 'Sophie Germain <sophie@civicpress.io>' reviewers:
-- 'Ada Lovelace'
-- 'Irène Joliot-Curie'
-
----
 
 ## Name
 

--- a/docs/specs/activity-log.md
+++ b/docs/specs/activity-log.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `activity-log.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive activity log documentation
-- event tracking
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'auth.md: >=1.2.0'
- - 'audit.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/add-version-headers.md
+++ b/docs/specs/add-version-headers.md
@@ -1,20 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `add-version-headers.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive version header documentation
-- maintenance guidelines
-- validation standards compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'spec-versioning.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `api.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive API documentation
-- security considerations
-- testing patterns compatibility: min_civicpress: 1.0.0 max_civicpress: 'null'
- dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/archive-policy.md
+++ b/docs/specs/archive-policy.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `archive-policy.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive archive policy documentation
-- data retention
-- authenticity preservation fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'public-data-structure.md: >=1.0.0'
- - 'storage.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/audit.md
+++ b/docs/specs/audit.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `audit.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive audit documentation
-- audit trails
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/auth.md
+++ b/docs/specs/auth.md
@@ -1,29 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-04'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `auth.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-04' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive testing examples
-- security testing patterns
-- performance testing
-- accessibility testing
-- compliance testing
-- CLI testing fixes:
-- testing section enhancement
-- code examples
-- validation patterns migration_guide: null compatibility: min_civicpress: 1.0.0
- max_civicpress: null dependencies:
- - 'permissions.md: >=1.0.0'
- - 'roles.yml.md: >=1.0.0'
- - 'signatures.md: >=1.0.0'
- - 'git-policy.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/backup.md
+++ b/docs/specs/backup.md
@@ -1,20 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `backup.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive backup documentation
-- disaster recovery
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'storage.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/branding.md
+++ b/docs/specs/branding.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `branding.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive branding documentation
-- brand compliance
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'ui.md: >=1.0.0'
- - 'themes.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -1,21 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `cli.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive CLI documentation
-- security considerations
-- testing patterns fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'auth.md: >=1.0.0'
- - 'permissions.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/data-integrity.md
+++ b/docs/specs/data-integrity.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `data-integrity.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive data integrity documentation
-- validation patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'public-data-structure.md: >=1.0.0'
- - 'records-validation.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/database.md
+++ b/docs/specs/database.md
@@ -1,20 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `database.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive database documentation
-- data modeling
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'storage.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/dependency-injection.md
+++ b/docs/specs/dependency-injection.md
@@ -1,19 +1,11 @@
+---
+version: '1.0.0'
+status: implemented
+created: '2025-01-27'
+updated: '2025-12-18'
+---
+
 # CivicPress Spec: `dependency-injection.md`
-
----
-
-version: 1.0.0 status: implemented created: '2025-01-27' updated: '2025-12-18'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- Dependency injection container system
-- Service registration and resolution
-- Lazy initialization support
-- Service lifecycle management fixes: [] migration_guide: null compatibility:
-  min_civicpress: '0.2.0' max_civicpress: null dependencies:
-- 'core.md: >=1.0.0' authors:
-- 'AI Assistant <assistant@civicpress.io>' reviewers: []
-
----
 
 ## Name
 

--- a/docs/specs/deployment.md
+++ b/docs/specs/deployment.md
@@ -1,20 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `deployment.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive deployment documentation
-- infrastructure patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'manifest.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/diagnostic-tools.md
+++ b/docs/specs/diagnostic-tools.md
@@ -1,11 +1,11 @@
+---
+version: '1.0.0'
+status: draft
+created: '2025-01-27'
+updated: '2025-01-27'
+---
+
 # CivicPress Spec: `diagnostic-tools.md`
-
----
-
-version: 1.0.0 status: draft created: '2025-01-27' updated: '2025-01-27'
-deprecated: false
-
----
 
 ## Name
 

--- a/docs/specs/editor-spec-v1.md
+++ b/docs/specs/editor-spec-v1.md
@@ -1,31 +1,11 @@
-# CivicPress Spec: `editor-spec-v1.md`
-
 ---
-version: 1.0.0
+version: '1.0.0'
 status: draft
 created: '2025-12-04'
 updated: '2026-06-15'
-deprecated: false
-sunset_date: null
-breaking_changes: []
-additions:
-  - Markdown editor with preview mode
-  - Autosave draft functionality
-  - Metadata sidebar management
-  - Publish/draft workflow
-fixes: []
-migration_guide: null
-compatibility:
-  min_civicpress: '1.0.0'
-  max_civicpress: null
-dependencies:
-  - 'records.md: >=1.0.0'
-  - 'api.md: >=1.0.0'
-  - 'frontend.md: >=1.0.0'
-authors:
-  - 'Core Team <team@civicpress.io>'
-reviewers: []
 ---
+
+# CivicPress Spec: `editor-spec-v1.md`
 
 ## ✅ As-Shipped Status (reconciled 2026-06-15)
 

--- a/docs/specs/editor-spec-v2.md
+++ b/docs/specs/editor-spec-v2.md
@@ -1,32 +1,11 @@
-# CivicPress Spec: `editor-spec-v2.md`
-
 ---
-version: 1.0.0
+version: '1.0.0'
 status: draft
 created: '2025-12-04'
 updated: '2026-06-15'
-deprecated: false
-sunset_date: null
-breaking_changes: []
-additions:
-  - Typora-style WYSIWYM editing experience
-  - Inline civic components (records, geographies, attachments)
-  - ProseMirror/Milkdown editor framework
-  - Reference extraction from Markdown
-fixes: []
-migration_guide: null
-compatibility:
-  min_civicpress: '1.0.0'
-  max_civicpress: null
-dependencies:
-  - 'editor-spec-v1.md: >=1.0.0'
-  - 'records.md: >=1.0.0'
-  - 'api.md: >=1.0.0'
-  - 'frontend.md: >=1.0.0'
-authors:
-  - 'Core Team <team@civicpress.io>'
-reviewers: []
 ---
+
+# CivicPress Spec: `editor-spec-v2.md`
 
 ## ⚠️ As-Shipped Status (reconciled 2026-06-15)
 

--- a/docs/specs/editor-spec-v3.md
+++ b/docs/specs/editor-spec-v3.md
@@ -1,33 +1,11 @@
-# CivicPress Spec: `editor-spec-v3.md`
-
 ---
-version: 1.0.0
+version: '1.0.0'
 status: draft
 created: '2025-12-04'
 updated: '2026-06-15'
-deprecated: false
-sunset_date: null
-breaking_changes: []
-additions:
-  - Real-time collaborative editing using yjs
-  - WebSocket-based document synchronization
-  - Presence indicators and cursor tracking
-  - Snapshot persistence for reconnection
-fixes: []
-migration_guide: null
-compatibility:
-  min_civicpress: '1.0.0'
-  max_civicpress: null
-dependencies:
-  - 'editor-spec-v2.md: >=1.0.0'
-  - 'realtime-architecture.md: >=1.0.0'
-  - 'records.md: >=1.0.0'
-  - 'api.md: >=1.0.0'
-  - 'frontend.md: >=1.0.0'
-authors:
-  - 'Core Team <team@civicpress.io>'
-reviewers: []
 ---
+
+# CivicPress Spec: `editor-spec-v3.md`
 
 ## ✅ As-Shipped Status (reconciled 2026-06-15)
 

--- a/docs/specs/feedback.md
+++ b/docs/specs/feedback.md
@@ -1,22 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `feedback.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive feedback documentation
-- feedback workflows
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'ui.md: >=1.0.0'
- - 'auth.md: >=1.0.0'
- - 'permissions.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/frontend.md
+++ b/docs/specs/frontend.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `frontend.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive frontend documentation
-- UI patterns
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'ui.md: >=1.0.0'
- - 'api.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/geography-data.md
+++ b/docs/specs/geography-data.md
@@ -1,3 +1,10 @@
+---
+version: '1.0.0'
+status: draft
+created: '2025-01-27'
+updated: '2025-01-27'
+---
+
 # ️ CivicPress Spec: `geography-data.md`
 
 > **Implementation status (2026-08-03).** **GeoJSON is the only supported
@@ -5,24 +12,6 @@
 > implemented". The Leaflet map, CRUD, and presets work; the database mirror is
 > write-only. Authoritative status: `docs/project-status.md` (Geography =
 > Partial).
-
----
-
-version: 1.0.0 status: draft created: '2025-01-27' updated: '2025-01-27'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- centralized geography data management system
-- text box input with API validation and file generation
-- live preview with Leaflet maps
-- public geography file access
-- geography data relationships
-- standardized geography file structure fixes: [] migration_guide: null
- compatibility: min_civicpress: 1.0.0 max_civicpress: null dependencies: []
- authors:
-- 'AI Assistant <ai@civicpress.io>' reviewers:
-- 'Development Team'
-
----
 
 ## Name
 

--- a/docs/specs/git-engine.md
+++ b/docs/specs/git-engine.md
@@ -1,21 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `git-engine.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- detailed YAML examples
-- comprehensive field definitions
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'auth.md: >=1.0.0'
- - 'permissions.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/git-policy.md
+++ b/docs/specs/git-policy.md
@@ -1,21 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `git-policy.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- detailed YAML examples
-- comprehensive field definitions
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'auth.md: >=1.0.0'
- - 'permissions.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/glossary.md
+++ b/docs/specs/glossary.md
@@ -1,22 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `glossary.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive glossary documentation
-- key terms
-- definitions fixes:
-- glossary documentation
-- term definitions
-- validation patterns migration_guide: null compatibility: min_civicpress: 1.0.0
- max_civicpress: null dependencies: [] authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## ️ CivicPress Glossary
 

--- a/docs/specs/health.md
+++ b/docs/specs/health.md
@@ -1,14 +1,11 @@
-# CivicPress Spec: `health.md`
-
 ---
-
-version: 0.2.x
+version: '0.2.x'
 status: partial
 created: '2025-01-15'
 updated: '2026-05-17'
-deprecated: false
-
 ---
+
+# CivicPress Spec: `health.md`
 
 ## Name
 

--- a/docs/specs/hooks.md
+++ b/docs/specs/hooks.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # 🪝 CivicPress Spec: `hooks.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- detailed YAML examples
-- comprehensive hook configurations
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'workflows.md: >=1.0.0'
- - 'plugins.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/indexing.md
+++ b/docs/specs/indexing.md
@@ -1,20 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `indexing.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive indexing documentation
-- search optimization
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'public-data-structure.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/legal-register.md
+++ b/docs/specs/legal-register.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2026-05-17'
+---
+
 # ️ CivicPress Spec: `legal-register.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2026-05-17'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive legal register documentation
-- document integrity
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 0.3.0 max_civicpress: 'null' dependencies:
- - 'public-data-structure.md: >=1.0.0'
- - 'records-validation.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 > **Status note (Phase 2b Truth Restoration, 2026-05-17):** This spec is `status: planned`. The described module is absent from v0.2.0 — see "Current implementation" below for what exists today. Closes audit findings `legal-register-001` and `legal-register-006`. Module build sequenced post-Phase-2d per refactor master plan §9.4. Triage rationale: `docs/audits/spec-stability-triage.md`.
 

--- a/docs/specs/lifecycle.md
+++ b/docs/specs/lifecycle.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `lifecycle.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive lifecycle documentation
-- state management
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'workflows.md: >=1.3.0'
- - 'status-tags.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/maintenance.md
+++ b/docs/specs/maintenance.md
@@ -1,20 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `maintenance.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive maintenance documentation
-- operational patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'deployment.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/manifest.md
+++ b/docs/specs/manifest.md
@@ -1,19 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `manifest.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- detailed YAML field definitions
-- comprehensive field documentation fixes: [] migration_guide: null
- compatibility: min_civicpress: 1.0.0 max_civicpress: 'null' dependencies: []
- authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/metrics.md
+++ b/docs/specs/metrics.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `metrics.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive metrics documentation
-- performance tracking
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'observability.md: >=1.0.0'
- - 'api.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/moderation.md
+++ b/docs/specs/moderation.md
@@ -1,22 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `moderation.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive moderation documentation
-- content integrity
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0'
- - 'users.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/module-api.md
+++ b/docs/specs/module-api.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `module-api.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive module API documentation
-- extension patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'plugins.md: >=1.5.0'
- - 'api.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/notifications.md
+++ b/docs/specs/notifications.md
@@ -1,3 +1,10 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `notifications.md`
 
 > **Implementation status (2026-08-03).** One real channel is wired — **email**
@@ -6,23 +13,6 @@
 > failures are reported truthfully (a real send error is recorded as a failed
 > send). Authoritative status: `docs/project-status.md` (Notifications =
 > Partial).
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive notification documentation
-- channel security
-- content protection compatibility: min_civicpress: 1.0.0 max_civicpress: 'null'
- dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/observability.md
+++ b/docs/specs/observability.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `observability.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive observability documentation
-- monitoring patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'api.md: >=1.0.0'
- - 'deployment.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/onboarding.md
+++ b/docs/specs/onboarding.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `onboarding.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive onboarding documentation
-- user experience patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'ui.md: >=1.0.0'
- - 'auth.md: >=1.2.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/permissions.md
+++ b/docs/specs/permissions.md
@@ -1,26 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `permissions.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive testing examples
-- security testing patterns
-- performance testing
-- compliance testing
-- CLI testing
-- detailed YAML field definitions fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'auth.md: >=1.0.0'
- - 'roles.yml.md: >=1.0.0'
- - 'workflows.md: >=1.0.0'
- - 'git-policy.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/plugin-api.md
+++ b/docs/specs/plugin-api.md
@@ -1,27 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-15'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `plugin-api.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-15' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive API interfaces
-- lifecycle hooks
-- UI widget API
-- hook system
-- route API
-- CLI API
-- testing frameworks
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'plugins.md: >=1.5.0'
- - 'hooks.md: >=1.2.0'
- - 'testing-framework.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/plugin-development.md
+++ b/docs/specs/plugin-development.md
@@ -1,23 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-04'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `plugin-development.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-04' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive plugin development documentation
-- security testing patterns
-- testing frameworks
-- development workflows compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'plugins.md: >=1.5.0'
- - 'plugin-api.md: >=1.0.0'
- - 'testing-framework.md: >=1.0.0' authors:
-- 'Sophie Germain <sophie@civicpress.io>' reviewers:
-- 'Ada Lovelace'
-- 'Irène Joliot-Curie'
-
----
 
 ## Name
 

--- a/docs/specs/plugins.md
+++ b/docs/specs/plugins.md
@@ -1,25 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-04'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `plugins.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-04' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive development examples
-- security testing patterns
-- CLI documentation
-- performance testing frameworks fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'auth.md: >=1.0.0'
- - 'permissions.md: >=1.0.0'
- - 'plugin-api.md: >=1.0.0'
- - 'plugin-development.md: >=1.0.0'
- - 'testing-framework.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/printable.md
+++ b/docs/specs/printable.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `printable.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive printable documentation
-- print formats
-- accessibility considerations compatibility: min_civicpress: 1.0.0
- max_civicpress: 'null' dependencies:
- - 'ui.md: >=1.0.0'
- - 'accessibility.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/public-data-structure.md
+++ b/docs/specs/public-data-structure.md
@@ -1,20 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `public-data-structure.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive data structure documentation
-- organization patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'manifest.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/realtime-architecture.md
+++ b/docs/specs/realtime-architecture.md
@@ -1,3 +1,10 @@
+---
+version: '1.0.0'
+status: as-shipped
+created: '2025-12-04'
+updated: '2026-06'
+---
+
 # CivicPress Spec: `realtime-architecture.md`
 
 > **Implementation status (2026-08-03).** The realtime service is implemented
@@ -6,24 +13,6 @@
 > **off by default**, and it is **single-node** — the multi-node Redis fan-out
 > described below is not built. Authoritative status: `docs/project-status.md`
 > (Realtime = Partial).
-
----
-
-version: 1.0.0 status: as-shipped (Phase 3, 2026-06) created: '2025-12-04' updated: '2026-06'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- WebSocket-based realtime service architecture
-- yjs document collaboration system
-- Presence tracking and room management
-- Snapshot persistence strategy fixes: [] migration_guide: null compatibility:
-  min_civicpress: '1.0.0' max_civicpress: null dependencies:
-- 'editor-spec-v3.md: >=1.0.0'
-- 'api.md: >=1.0.0'
-- 'auth.md: >=1.0.0'
-- 'permissions.md: >=1.0.0' authors:
-- 'Core Team <team@civicpress.io>' reviewers: []
-
----
 
 ## As-shipped status (Phase 3, 2026-06)
 

--- a/docs/specs/records-validation.md
+++ b/docs/specs/records-validation.md
@@ -1,20 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `records-validation.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive validation documentation
-- integrity patterns
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'public-data-structure.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/records.md
+++ b/docs/specs/records.md
@@ -1,14 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-01-15'
+updated: '2025-01-15'
+---
+
 # CivicPress Spec: `records.md`
-
----
-
-version: 1.0.0 
-status: stable 
-created: '2025-01-15' 
-updated: '2025-01-15' 
-deprecated: false
-
----
 
 ## Name
 

--- a/docs/specs/review-policy.md
+++ b/docs/specs/review-policy.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `review-policy.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive review policy documentation
-- review workflows
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'permissions.md: >=1.1.0'
- - 'workflows.md: >=1.3.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/roles.yml.md
+++ b/docs/specs/roles.yml.md
@@ -1,21 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ‍ CivicPress Spec: `roles.yml.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive roles documentation
-- YAML schema
-- security considerations fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'permissions.md: >=1.0.0'
- - 'auth.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/scheduler.md
+++ b/docs/specs/scheduler.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ⏰ CivicPress Spec: `scheduler.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive scheduler documentation
-- execution security
-- automation patterns compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'workflows.md: >=1.3.0'
- - 'hooks.md: >=1.2.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/security.md
+++ b/docs/specs/security.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `security.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive security documentation
-- threat modeling
-- testing patterns compatibility: min_civicpress: 1.0.0 max_civicpress: 'null'
- dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/serve.md
+++ b/docs/specs/serve.md
@@ -1,21 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `serve.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive serve documentation
-- hosting patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'deployment.md: >=1.0.0'
- - 'static-export.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/session-recorder-integration.md
+++ b/docs/specs/session-recorder-integration.md
@@ -1,5 +1,7 @@
 # CivicPress – Session Recorder Integration
 
+**Status**: Implemented
+
 ## Purpose
 
 This document describes how a session recorder box integrates with CivicPress to

--- a/docs/specs/signatures.md
+++ b/docs/specs/signatures.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `signatures.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive signature documentation
-- digital signatures
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/spec-guidelines.md
+++ b/docs/specs/spec-guidelines.md
@@ -1,19 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-04'
+updated: '2025-07-04'
+---
+
 # CivicPress Spec: `spec-guidelines.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-04' updated: '2025-07-04'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- standardized spec format
-- metadata fields
-- authorship tracking fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: null dependencies: [] authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Tim Berners-Lee
-
----
 
 ## Name
 

--- a/docs/specs/spec-versioning.md
+++ b/docs/specs/spec-versioning.md
@@ -1,15 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-04'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `spec-versioning.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-04' updated: '2025-07-15'
-deprecated: false sunset_date: null authors:
-
-- 'Sophie Germain <sophie@civicpress.io>' reviewers:
-- 'Ada Lovelace'
-- 'Irène Joliot-Curie'
-
----
 
 ## Name
 

--- a/docs/specs/static-export.md
+++ b/docs/specs/static-export.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `static-export.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive static export documentation
-- asset validation
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'ui.md: >=1.0.0'
- - 'public-data-structure.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/status-tags.md
+++ b/docs/specs/status-tags.md
@@ -1,21 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `status-tags.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive status tag documentation
-- transition security
-- abuse prevention compatibility: min_civicpress: 1.0.0 max_civicpress: 'null'
- dependencies:
- - 'workflows.md: >=1.3.0'
- - 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/storage.md
+++ b/docs/specs/storage.md
@@ -1,3 +1,10 @@
+---
+version: '2.1.0'
+status: partial
+created: '2025-07-03'
+updated: '2026-08-03'
+---
+
 # ️ CivicPress Spec: `storage.md`
 
 > **Implementation status (2026-08-03).** The local-filesystem provider is
@@ -10,31 +17,6 @@
 > action moves no file today). The live circuit breaker, timeouts, quota, and
 > usage reporting are unaffected. The authoritative, code-verified status is
 > `docs/project-status.md` (Storage = Partial).
-
----
-
-version: 2.1.0 status: partial created: '2025-07-03' updated: '2026-08-03'
-deprecated: false sunset_date: null additions:
-
-- comprehensive storage documentation
-- UUID-based file management system
-- multi-provider backend support
-- file attachment system integration
-- data management
-- security considerations
-- performance optimizations (caching, batch, streaming)
-- reliability improvements (retry, failover, circuit breaker)
-- observability & management (metrics, quota, lifecycle)
-- enhanced error handling
-
-compatibility: min_civicpress: 2.0.0 max_civicpress: 'null' dependencies: []
-authors:
-
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/templates.md
+++ b/docs/specs/templates.md
@@ -1,29 +1,11 @@
+---
+version: '2.0.0'
+status: stable
+created: '2025-01-15'
+updated: '2025-12-17'
+---
+
 # CivicPress Spec: `templates.md`
-
----
-
-version: 2.0.0 status: stable created: '2025-01-15' updated: '2025-12-17'
-implementation_status: completed deprecated: false sunset_date: null
-breaking_changes: [] additions:
-
-- Comprehensive API endpoint specifications
-- Template service layer architecture
-- Security and permission model
-- Error handling and validation
-- Caching strategy
-- Template ID format standardization fixes:
-- API endpoint structure inconsistencies
-- Missing error handling specifications
-- Incomplete permission model migration_guide: null compatibility:
-  min_civicpress: '0.2.0' max_civicpress: null dependencies:
-- 'auth.md: >=1.2.0'
-- 'permissions.md: >=1.1.0'
-- 'records.md: >=1.0.0' authors:
-- 'Sophie Germain <sophie@civicpress.io>' reviewers:
-- 'Ada Lovelace'
-- 'Irène Joliot-Curie'
-
----
 
 ## Name
 

--- a/docs/specs/testing-framework.md
+++ b/docs/specs/testing-framework.md
@@ -1,3 +1,10 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-15'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `testing-framework.md`
 
 > **Implementation status (2026-08-03).** Unit and integration testing (Vitest,
@@ -6,30 +13,6 @@
 > no Playwright/Cypress suite (the `@playwright/test` reference is aspirational),
 > no performance harness, and no a11y test suite. Authoritative status:
 > `docs/project-status.md`.
-
----
-
-version: 0.2.x status: partial created: '2025-07-15' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive testing standards
-- tools
-- patterns
-- utilities covering unit
-- integration
-- E2E
-- security
-- performance
-- and accessibility testing compatibility: min_civicpress: 1.0.0 max_civicpress:
-  'null' dependencies:
-- 'plugins.md: >=1.5.0'
-- 'auth.md: >=1.2.0'
-- 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/themes.md
+++ b/docs/specs/themes.md
@@ -1,20 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `themes.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive theme documentation
-- customization patterns
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'ui.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/timeline.md
+++ b/docs/specs/timeline.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `timeline.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive timeline documentation
-- chronological tracking
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'public-data-structure.md: >=1.0.0'
- - 'workflows.md: >=1.3.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/translations.md
+++ b/docs/specs/translations.md
@@ -1,20 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `translations.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive translation documentation
-- internationalization
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'ui.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/ui.md
+++ b/docs/specs/ui.md
@@ -1,21 +1,11 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `ui.md`
-
----
-
-version: 0.2.x status: partial created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive UI documentation
-- accessibility considerations
-- testing patterns fixes: [] migration_guide: null compatibility:
- min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
- - 'auth.md: >=1.0.0'
- - 'permissions.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/users.md
+++ b/docs/specs/users.md
@@ -1,22 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `users.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive user management documentation
-- security considerations
-- testing patterns compatibility: min_civicpress: 1.0.0 max_civicpress: 'null'
- dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0'
- - 'database.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/version-tracker.md
+++ b/docs/specs/version-tracker.md
@@ -1,20 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-15'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `version-tracker.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-15' updated: '2025-07-15'
-deprecated: false sunset_date: null breaking_changes: [] additions:
-
-- comprehensive version tracking documentation
-- dependency management
-- compatibility matrices fixes: [] migration_guide: null compatibility:
-  min_civicpress: 1.0.0 max_civicpress: 'null' dependencies:
-- 'spec-versioning.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/versioning.md
+++ b/docs/specs/versioning.md
@@ -1,20 +1,11 @@
+---
+version: '1.0.0'
+status: stable
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # CivicPress Spec: `versioning.md`
-
----
-
-version: 1.0.0 status: stable created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive versioning documentation
-- version management
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'git-policy.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/votes.md
+++ b/docs/specs/votes.md
@@ -1,21 +1,11 @@
+---
+version: '0.3.x-scope'
+status: planned
+created: '2025-07-03'
+updated: '2025-07-15'
+---
+
 # ️ CivicPress Spec: `votes.md`
-
----
-
-version: 0.3.x-scope status: planned created: '2025-07-03' updated: '2025-07-15'
-deprecated: false sunset_date: null additions:
-
-- comprehensive voting documentation
-- vote integrity
-- security considerations compatibility: min_civicpress: 1.0.0 max_civicpress:
- 'null' dependencies:
- - 'auth.md: >=1.2.0'
- - 'permissions.md: >=1.1.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/docs/specs/workflows.md
+++ b/docs/specs/workflows.md
@@ -1,3 +1,10 @@
+---
+version: '0.2.x'
+status: partial
+created: '2025-07-03'
+updated: '2026-05-17'
+---
+
 # CivicPress Workflows Specification
 
 > **Implementation status (2026-08-03).** Only one built-in workflow is
@@ -7,31 +14,6 @@
 > user-workflow loader or sandbox, and the REST `workflows` route is a `501`
 > stub. Authoritative status: `docs/project-status.md` (Workflow engine =
 > Partial).
-
-version: 0.2.x
-status: partial
-created: 2025-07-03
-updated: 2026-05-17
-deprecated: false
-sunset_date: null
-breaking_changes: []
-
-additions:
-
-- Session recorder integration workflow triggers
-- YAML-based workflow configuration
-- Manual workflow actions (UI triggers)
-- Enhanced security considerations fixes: []  
-  migration_guide: null  
-  compatibility: min_civicpress: 1.0.0 max_civicpress: null dependencies:
-- 'auth.md: >=1.0.0'
-- 'permissions.md: >=1.0.0'
-- 'hooks.md: >=1.0.0' authors:
-- Sophie Germain <sophie@civicpress.io> reviewers:
-- Ada Lovelace
-- Irène Joliot-Curie
-
----
 
 ## Name
 

--- a/modules/storage/src/__tests__/live-s3-minio.test.ts
+++ b/modules/storage/src/__tests__/live-s3-minio.test.ts
@@ -1,0 +1,181 @@
+/**
+ * LIVE S3 integration test.
+ *
+ * Every other storage test drives the cloud providers against a MOCKED SDK
+ * boundary (fake `s3Client.send`). This one exercises the real
+ * upload / download / delete ops against a real S3-compatible server — minio —
+ * so the actual AWS SDK wire calls, streaming, and byte round-trip are covered.
+ *
+ * OPT-IN: runs only when `CIVIC_TEST_LIVE_S3=1`, so normal CI stays hermetic
+ * (no server required). To run it:
+ *
+ *   # 1. start minio (any S3-compatible server works)
+ *   minio server /tmp/minio-data --address :9000    # user/pass minioadmin
+ *   # 2. run the suite
+ *   CIVIC_TEST_LIVE_S3=1 npx vitest run modules/storage/src/__tests__/live-s3-minio.test.ts
+ *
+ * Overridable env (defaults target a local minio):
+ *   CIVIC_TEST_S3_ENDPOINT   default http://127.0.0.1:9000
+ *   S3_ACCESS_KEY_ID         default minioadmin
+ *   S3_SECRET_ACCESS_KEY     default minioadmin
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  S3Client,
+  CreateBucketCommand,
+  HeadBucketCommand,
+} from '@aws-sdk/client-s3';
+import { CloudUuidStorageService } from '../cloud-uuid-storage-service.js';
+import type {
+  StorageConfig,
+  StorageProvider,
+  StorageFile,
+  MulterFile,
+  StorageDatabaseService,
+} from '../types/storage.types.js';
+
+const LIVE = process.env.CIVIC_TEST_LIVE_S3 === '1';
+const ENDPOINT = process.env.CIVIC_TEST_S3_ENDPOINT || 'http://127.0.0.1:9000';
+const ACCESS = process.env.S3_ACCESS_KEY_ID || 'minioadmin';
+const SECRET = process.env.S3_SECRET_ACCESS_KEY || 'minioadmin';
+const BUCKET = 'civic-live-test';
+
+// Minimal in-memory DB double — only the methods the ops touch.
+class MockDb {
+  private files = new Map<string, StorageFile>();
+  async createStorageFile(f: StorageFile) {
+    this.files.set(f.id, f);
+  }
+  async getStorageFileById(id: string) {
+    return this.files.get(id) ?? null;
+  }
+  async getStorageFilesByFolder(folder: string) {
+    return [...this.files.values()].filter((f) => f.folder === folder);
+  }
+  async deleteStorageFile(id: string) {
+    return this.files.delete(id);
+  }
+}
+
+const silentLogger = () =>
+  ({ debug() {}, info() {}, warn() {}, error() {} }) as never;
+
+function multerFile(
+  originalname: string,
+  buffer: Buffer,
+  mimetype = 'application/octet-stream'
+): MulterFile {
+  return {
+    fieldname: 'file',
+    originalname,
+    encoding: '7bit',
+    mimetype,
+    size: buffer.length,
+    destination: '',
+    filename: originalname,
+    path: '',
+    buffer,
+  };
+}
+
+describe.skipIf(!LIVE)('S3 live integration (minio)', () => {
+  let service: CloudUuidStorageService;
+  let dir = '';
+
+  beforeAll(async () => {
+    const client = new S3Client({
+      region: 'us-east-1',
+      endpoint: ENDPOINT,
+      forcePathStyle: true,
+      credentials: { accessKeyId: ACCESS, secretAccessKey: SECRET },
+    });
+
+    // Ensure the bucket exists (idempotent).
+    try {
+      await client.send(new HeadBucketCommand({ Bucket: BUCKET }));
+    } catch {
+      await client.send(new CreateBucketCommand({ Bucket: BUCKET }));
+    }
+
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'civic-live-s3-'));
+    const provider: StorageProvider = {
+      type: 's3',
+      enabled: true,
+      region: 'us-east-1',
+      bucket: BUCKET,
+      endpoint: ENDPOINT,
+      options: { force_path_style: true },
+    } as StorageProvider;
+
+    const config = {
+      backend: { type: 'local' },
+      active_provider: 's3',
+      providers: {
+        local: { type: 'local', enabled: true, path: 'storage' },
+        s3: provider,
+      },
+      folders: {
+        public: {
+          path: 'public',
+          access: 'public',
+          allowed_types: ['*'],
+          max_size: '100MB',
+        },
+      },
+      global: { circuit_breaker_enabled: false, quota_enforcement: false },
+      metadata: {},
+    } as unknown as StorageConfig;
+
+    service = new CloudUuidStorageService(config, dir);
+    service.logger = silentLogger();
+    service.setDatabaseService(new MockDb() as unknown as StorageDatabaseService);
+    // Drive the real ops against minio through the same public field the mocked
+    // suite uses — no fake `send`, so the actual SDK PUT/GET/DELETE hit the wire.
+    service.s3Client = client as never;
+  });
+
+  afterAll(async () => {
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips a file end to end: upload → getFileContent → delete', async () => {
+    const payload = Buffer.from(
+      'civic live storage payload — real minio round-trip 🏛️'
+    );
+
+    const res = await service.uploadFile({
+      file: multerFile('live.txt', payload, 'text/plain'),
+      folder: 'public',
+      uploaded_by: 'live-test',
+    });
+    expect(res.success).toBe(true);
+    expect(res.file!.provider_path).toMatch(
+      /^s3:\/\/civic-live-test\/public\//
+    );
+
+    // Read the bytes back out of minio.
+    const got = await service.getFileContent(res.file!.id);
+    expect(got).toEqual(payload);
+
+    // Delete and confirm it's gone.
+    const deleted = await service.deleteFile(res.file!.id);
+    expect(deleted).toBe(true);
+    expect(await service.getFileById(res.file!.id)).toBeNull();
+  });
+
+  it('lists an uploaded object then cleans it up', async () => {
+    const res = await service.uploadFile({
+      file: multerFile('listed.bin', Buffer.from([1, 2, 3, 4]), 'application/octet-stream'),
+      folder: 'public',
+    });
+    expect(res.success).toBe(true);
+
+    const listed = await service.listFiles('public');
+    expect(listed.some((f) => f.id === res.file!.id)).toBe(true);
+
+    await service.deleteFile(res.file!.id);
+  });
+});

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,21 @@
+# osv-scanner ignore list — accepted, documented residual advisories.
+#
+# Read automatically from the repo root by both scans in
+# .github/workflows/osv-scanner.yml (the scheduled report-only full scan and the
+# fail-on-vuln PR scan). Every entry must record WHY the advisory is accepted.
+
+[[IgnoredVulns]]
+id = "GHSA-mh99-v99m-4gvg"
+reason = """
+brace-expansion flat-range ReDoS/DoS (alias CVE-2026-14257). Accepted residual:
+the fix lands only in brace-expansion 5.x, which is ESM-only and cannot be forced
+under the CJS minimatch/glob consumers in this dependency tree — brace-expansion
+is pinned via pnpm.overrides (1.1.16 / 2.1.2) accordingly. Not reachable from the
+request surface (build/test tooling only). Already an accepted residual on main;
+it re-surfaced on the v0.3.0 branch solely because @playwright/test's dependency
+tree adds more instances of the same already-pinned versions.
+"""
+
+[[IgnoredVulns]]
+id = "CVE-2026-14257"
+reason = "Alias of GHSA-mh99-v99m-4gvg (brace-expansion flat-range DoS) — see above."

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "1.48.0",
+    "@playwright/test": "1.55.1",
     "@types/bcrypt": "5.0.2",
     "@types/nodemailer": "6.4.17",
     "@vitejs/plugin-vue": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "test:watch": "vitest --watch",
     "i18n:check": "node scripts/i18n-parity.mjs",
     "specs:check": "node scripts/check-spec-frontmatter.mjs",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "gen": "plop",
     "gen:page": "plop nuxt:page",
     "gen:cli": "plop cli:command",
@@ -67,6 +69,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@playwright/test": "1.48.0",
     "@types/bcrypt": "5.0.2",
     "@types/nodemailer": "6.4.17",
     "@vitejs/plugin-vue": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "civicpress",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "CivicPress project",
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "i18n:check": "node scripts/i18n-parity.mjs",
+    "specs:check": "node scripts/check-spec-frontmatter.mjs",
     "gen": "plop",
     "gen:page": "plop nuxt:page",
     "gen:cli": "plop cli:command",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,9 @@ export default defineConfig({
     command: WEBSERVER,
     url: `http://127.0.0.1:${PORT}/`,
     reuseExistingServer: true,
-    timeout: 150_000,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
     env: { PORT, NUXT_PORT: PORT },
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Browser end-to-end tests. These drive the REAL CivicPress web UI (the Nuxt
+ * SPA) in a real Chromium — the layer the vitest component tests and the
+ * supertest API-level journey tests (tests/e2e/) can't reach: real routing,
+ * hydration, and rendering in a browser. The API is intercepted with fixtures
+ * inside each spec, so no live backend/DB is required.
+ *
+ * Local run:
+ *   npx playwright install chromium         # one-time
+ *   npx playwright test                     # auto-starts the UI dev server
+ *
+ * The UI port is overridable via CIVIC_E2E_PORT (default 3041). If a UI server
+ * is already listening there, Playwright reuses it.
+ */
+const PORT = process.env.CIVIC_E2E_PORT || '3041';
+// Local default: the Nuxt dev server (no build needed). CI overrides this with
+// the built preview (`pnpm --filter @civicpress/ui run preview`) after a build.
+const WEBSERVER =
+  process.env.CIVIC_E2E_WEBSERVER || `pnpm --filter @civicpress/ui run dev`;
+
+export default defineConfig({
+  testDir: './tests/e2e-browser',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    headless: true,
+    trace: 'off',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: WEBSERVER,
+    url: `http://127.0.0.1:${PORT}/`,
+    reuseExistingServer: true,
+    timeout: 150_000,
+    env: { PORT, NUXT_PORT: PORT },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ importers:
         version: 3.1048.0
     devDependencies:
       '@playwright/test':
-        specifier: 1.48.0
-        version: 1.48.0
+        specifier: 1.55.1
+        version: 1.55.1
       '@types/bcrypt':
         specifier: 5.0.2
         version: 5.0.2
@@ -748,7 +748,7 @@ importers:
         version: 1.2.111
       '@nuxt/test-utils':
         specifier: ^3.23.0
-        version: 3.23.0(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)
+        version: 3.23.0(@jest/globals@29.7.0)(@playwright/test@1.55.1)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.6)
       '@typescript-eslint/eslint-plugin':
         specifier: 8.60.0
         version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -3058,8 +3058,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.48.0':
-    resolution: {integrity: sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==}
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7615,13 +7615,13 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.48.0:
-    resolution: {integrity: sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==}
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.48.0:
-    resolution: {integrity: sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==}
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11427,7 +11427,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@3.23.0(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)':
+  '@nuxt/test-utils@3.23.0(@jest/globals@29.7.0)(@playwright/test@1.55.1)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.6)':
     dependencies:
       '@clack/prompts': 1.0.0-alpha.9
       '@nuxt/kit': 3.21.6(magicast@0.5.3)
@@ -11455,16 +11455,16 @@ snapshots:
       tinyexec: 1.2.4
       ufo: 1.6.4
       unplugin: 2.3.11
-      vitest-environment-nuxt: 1.0.1(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)
+      vitest-environment-nuxt: 1.0.1(@jest/globals@29.7.0)(@playwright/test@1.55.1)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.6)
       vue: 3.5.35(typescript@5.9.3)
     optionalDependencies:
       '@jest/globals': 29.7.0
-      '@playwright/test': 1.48.0
+      '@playwright/test': 1.55.1
       '@vitest/ui': 3.2.6(vitest@3.2.6)
       '@vue/test-utils': 2.4.6
       happy-dom: 20.8.9
       jsdom: 29.1.1(@noble/hashes@1.8.0)
-      playwright-core: 1.48.0
+      playwright-core: 1.55.1
       vitest: 3.2.6(@types/node@20.19.41)(@vitest/ui@3.2.6)(happy-dom@20.8.9)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
       - crossws
@@ -12315,9 +12315,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.48.0':
+  '@playwright/test@1.55.1':
     dependencies:
-      playwright: 1.48.0
+      playwright: 1.55.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -17670,11 +17670,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.48.0: {}
+  playwright-core@1.55.1: {}
 
-  playwright@1.48.0:
+  playwright@1.55.1:
     dependencies:
-      playwright-core: 1.48.0
+      playwright-core: 1.55.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -19292,9 +19292,9 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.8.3
 
-  vitest-environment-nuxt@1.0.1(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6):
+  vitest-environment-nuxt@1.0.1(@jest/globals@29.7.0)(@playwright/test@1.55.1)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.6):
     dependencies:
-      '@nuxt/test-utils': 3.23.0(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)
+      '@nuxt/test-utils': 3.23.0(@jest/globals@29.7.0)(@playwright/test@1.55.1)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.55.1)(typescript@5.9.3)(vitest@3.2.6)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
         specifier: 3.1048.0
         version: 3.1048.0
     devDependencies:
+      '@playwright/test':
+        specifier: 1.48.0
+        version: 1.48.0
       '@types/bcrypt':
         specifier: 5.0.2
         version: 5.0.2
@@ -745,7 +748,7 @@ importers:
         version: 1.2.111
       '@nuxt/test-utils':
         specifier: ^3.23.0
-        version: 3.23.0(@jest/globals@29.7.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(typescript@5.9.3)(vitest@3.2.6)
+        version: 3.23.0(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)
       '@typescript-eslint/eslint-plugin':
         specifier: 8.60.0
         version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -3054,6 +3057,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.48.0':
+    resolution: {integrity: sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -5962,6 +5970,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7601,6 +7614,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.48.0:
+    resolution: {integrity: sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.48.0:
+    resolution: {integrity: sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plop@4.0.5:
     resolution: {integrity: sha512-pJz6oWC9LyBp5mBrRp8AUV2RNiuGW+t/HOs4zwN+b/3YxoObZOOFvjn1mJMpAeKi2pbXADMFOOVQVTVXEdDHDw==}
@@ -11404,7 +11427,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@3.23.0(@jest/globals@29.7.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(typescript@5.9.3)(vitest@3.2.6)':
+  '@nuxt/test-utils@3.23.0(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)':
     dependencies:
       '@clack/prompts': 1.0.0-alpha.9
       '@nuxt/kit': 3.21.6(magicast@0.5.3)
@@ -11432,14 +11455,16 @@ snapshots:
       tinyexec: 1.2.4
       ufo: 1.6.4
       unplugin: 2.3.11
-      vitest-environment-nuxt: 1.0.1(@jest/globals@29.7.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(typescript@5.9.3)(vitest@3.2.6)
+      vitest-environment-nuxt: 1.0.1(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)
       vue: 3.5.35(typescript@5.9.3)
     optionalDependencies:
       '@jest/globals': 29.7.0
+      '@playwright/test': 1.48.0
       '@vitest/ui': 3.2.6(vitest@3.2.6)
       '@vue/test-utils': 2.4.6
       happy-dom: 20.8.9
       jsdom: 29.1.1(@noble/hashes@1.8.0)
+      playwright-core: 1.48.0
       vitest: 3.2.6(@types/node@20.19.41)(@vitest/ui@3.2.6)(happy-dom@20.8.9)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
     transitivePeerDependencies:
       - crossws
@@ -12289,6 +12314,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.48.0':
+    dependencies:
+      playwright: 1.48.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -15491,6 +15520,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -17638,6 +17670,14 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  playwright-core@1.48.0: {}
+
+  playwright@1.48.0:
+    dependencies:
+      playwright-core: 1.48.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   plop@4.0.5(@types/node@20.19.41):
     dependencies:
       '@types/liftoff': 4.0.3
@@ -19252,9 +19292,9 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.8.3
 
-  vitest-environment-nuxt@1.0.1(@jest/globals@29.7.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(typescript@5.9.3)(vitest@3.2.6):
+  vitest-environment-nuxt@1.0.1(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6):
     dependencies:
-      '@nuxt/test-utils': 3.23.0(@jest/globals@29.7.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(typescript@5.9.3)(vitest@3.2.6)
+      '@nuxt/test-utils': 3.23.0(@jest/globals@29.7.0)(@playwright/test@1.48.0)(@vitest/ui@3.2.6)(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.16))(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(magicast@0.5.3)(playwright-core@1.48.0)(typescript@5.9.3)(vitest@3.2.6)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'

--- a/scripts/check-spec-frontmatter.mjs
+++ b/scripts/check-spec-frontmatter.mjs
@@ -1,0 +1,70 @@
+// Validate docs/specs/*.md frontmatter.
+//
+// A spec need not have frontmatter (README and historical dated design docs use
+// other conventions), but any top-of-file frontmatter present MUST parse as YAML
+// and — if it declares `status` — declare a KNOWN status. This is the machine
+// side of the v0.3.x "specs match reality" gate: it keeps the status tags honest
+// and prevents a relapse into the jammed single-line metadata that used to sit
+// after the title.
+//
+// Exports `checkFrontmatter` (pure) for the vitest gate
+// (tests/ui/spec-frontmatter.test.ts); run directly for a local report:
+//   node scripts/check-spec-frontmatter.mjs   (or: pnpm specs:check)
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+
+export const VALID_STATUS = new Set([
+  'stable',
+  'partial',
+  'planned',
+  'draft',
+  'design',
+  'implemented',
+  'as-shipped',
+  'pending',
+]);
+
+/**
+ * Returns null if OK, else an error string. No frontmatter → OK. Frontmatter
+ * present → it must parse, and a declared `status`'s first token (so
+ * `design (draft)` is fine) must be a known value.
+ */
+export function checkFrontmatter(name, content) {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  let data;
+  try {
+    data = yaml.load(m[1]);
+  } catch (e) {
+    return `frontmatter does not parse: ${String(e.message).split('\n')[0]}`;
+  }
+  if (data && data.status !== undefined) {
+    const token = String(data.status).trim().split(/[\s(]/)[0];
+    if (!VALID_STATUS.has(token)) {
+      return `unknown status '${data.status}' (token '${token}')`;
+    }
+  }
+  return null;
+}
+
+/** Check every `*.md` under `dir`; returns an array of {file, error}. */
+export function checkSpecsDir(dir) {
+  const problems = [];
+  for (const f of readdirSync(dir).filter((x) => x.endsWith('.md'))) {
+    const err = checkFrontmatter(f, readFileSync(join(dir, f), 'utf8'));
+    if (err) problems.push({ file: f, error: err });
+  }
+  return problems;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const problems = checkSpecsDir('docs/specs');
+  if (problems.length === 0) {
+    console.log('spec-frontmatter OK — all frontmatter parses with a known status.');
+    process.exit(0);
+  }
+  for (const p of problems) console.error(`  ${p.file}: ${p.error}`);
+  console.error(`\nspec-frontmatter check FAILED (${problems.length}).`);
+  process.exit(1);
+}

--- a/scripts/spec-validate.mjs
+++ b/scripts/spec-validate.mjs
@@ -15,8 +15,14 @@ const specs = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
 for (const f of specs) {
   const p = path.join(dir, f);
   const txt = fs.readFileSync(p, 'utf8');
-  const hasHeader = /^#\s+/.test(txt);
-  const hasStatus = /\bStatus\s*:/i.test(txt);
+  // Specs now carry their metadata as standard top-of-file YAML frontmatter, so
+  // strip a leading `---...---` block before checking for the H1 title. (The
+  // status also lives in that frontmatter as `status:`.)
+  const afterFrontmatter = txt.replace(/^---\n[\s\S]*?\n---\n/, '');
+  const hasHeader = /^\s*#\s+/.test(afterFrontmatter);
+  // Accept the status in frontmatter (`status:`) or as a bold-prose header
+  // (`**Status**:`) — both conventions are in use across the specs.
+  const hasStatus = /\bStatus[\s*]*:/i.test(txt);
   if (!hasHeader || !hasStatus) {
     failures++;
     console.log(`Spec issue: ${f} -> missing ${!hasHeader ? 'header' : ''}${!hasHeader && !hasStatus ? ' and ' : ''}${!hasStatus ? 'status' : ''}`);

--- a/tests/e2e-browser/smoke.spec.ts
+++ b/tests/e2e-browser/smoke.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Browser smoke journeys against the real UI SPA with the API stubbed at the
+ * network boundary (page.route). Verifies the app actually boots, routes, and
+ * renders in Chromium — complementing the API-level create→edit→publish journey
+ * in tests/e2e/editor-workflows.test.ts.
+ */
+
+const orgInfo = {
+  success: true,
+  data: { organization: { name: 'Testville', city: 'Testville' } },
+};
+
+const recordsList = {
+  success: true,
+  data: {
+    records: [
+      {
+        id: 'rec-1',
+        title: 'Budget Bylaw 2026',
+        type: 'bylaw',
+        status: 'published',
+        updated_at: '2026-01-02T00:00:00Z',
+      },
+    ],
+    total: 1,
+    page: 1,
+    pageSize: 10,
+  },
+};
+
+/** Fulfil every /api/v1/* call the SPA makes with a fixture. */
+async function stubApi(page: Page) {
+  await page.route('**/api/v1/**', async (route) => {
+    const url = route.request().url();
+    if (url.includes('/info')) return route.fulfill({ json: orgInfo });
+    if (url.includes('/auth/me')) return route.fulfill({ status: 401, json: { success: false } });
+    if (url.includes('/records')) return route.fulfill({ json: recordsList });
+    return route.fulfill({ json: { success: true, data: {} } });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await stubApi(page);
+});
+
+test('the app boots and hydrates in a real browser', async ({ page }) => {
+  const res = await page.goto('/');
+  expect(res?.ok()).toBeTruthy();
+  await expect(page).toHaveTitle(/civicpress/i);
+  // The SPA actually rendered its content (not a white-screen crash).
+  await expect(
+    page.getByText(/open infrastructure for accountable local government/i)
+  ).toBeVisible();
+});
+
+test('the records browser renders a record from the API', async ({ page }) => {
+  await page.goto('/records');
+  await expect(page.getByText('Budget Bylaw 2026')).toBeVisible();
+});
+
+test('the login page renders its username + password form', async ({ page }) => {
+  await page.goto('/auth/login');
+  // Assert on CSS-visible text: a cookie-consent modal marks the rest of the
+  // page aria-hidden/inert, so role/label locators can't see the form, but its
+  // text still renders. This is the username/password login form.
+  await expect(page.getByText('Username & Password')).toBeVisible();
+  await expect(
+    page.getByText(/sign in with your username and password/i)
+  ).toBeVisible();
+});

--- a/tests/ui/spec-frontmatter.test.ts
+++ b/tests/ui/spec-frontmatter.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { checkFrontmatter } from '../../scripts/check-spec-frontmatter.mjs';
+
+/**
+ * CI guard for the v0.3.x "specs match reality" gate. Every spec under
+ * docs/specs/ that carries top-of-file frontmatter must parse and declare a
+ * known status. Backs the local `pnpm specs:check` script
+ * (scripts/check-spec-frontmatter.mjs). Runs here because the UI vitest suite
+ * runs in CI.
+ */
+describe('spec frontmatter (docs/specs)', () => {
+  const dir = join(process.cwd(), 'docs/specs');
+
+  it('every spec with frontmatter parses and declares a known status', () => {
+    const problems = readdirSync(dir)
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => ({
+        file: f,
+        error: checkFrontmatter(f, readFileSync(join(dir, f), 'utf8')),
+      }))
+      .filter((x) => x.error);
+    // On failure the array names the offending spec(s) and why.
+    expect(problems).toEqual([]);
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -80,6 +80,7 @@ export default defineConfig({
       '**/cli/node_modules/**',    // Skip CLI dependencies
       '**/core/node_modules/**',   // Skip core dependencies
       'tests/ui/**',               // Exclude UI tests (use vitest.config.ui.mjs with happy-dom)
+      'tests/e2e-browser/**',      // Playwright browser specs — run via `pnpm e2e`, not vitest
       // QUARANTINE — BURNED DOWN 2026-07-17 (phase-7e test-health). The 5 files
       // that formerly failed deterministically from a clean checkout are fixed
       // and now pass individually AND together from clean; they run in CI again.


### PR DESCRIPTION
## Release v0.3.0

Completes the **v0.3.x — "Editor, Attachments & Civic UX"** milestone. Branch
protection means a maintainer merges + tags; this PR is the reviewable proposal.

The milestone's **feature** work already shipped in **0.2.1** (rich editor,
drag-and-drop attachments, i18n/equity, the spec-reality gate). 0.3.0 adds the
remaining **test and documentation completion** so the exit criteria are
genuinely met — the "full sweep" of the deferred items:

### Added

- **Browser end-to-end layer (Playwright + Chromium).** Drives the real Nuxt UI
  SPA in a headless browser with the API stubbed at the network boundary — the
  layer the vitest component tests and the API-level journey tests (`tests/e2e/`)
  can't reach. Smoke journeys (app boots + hydrates, records browser renders from
  a fixtured API, login form renders) + a SHA-pinned `browser-e2e` CI workflow.
  `pnpm e2e`.
- **Live cloud-storage integration test.** Real S3 upload → download → delete
  round-trip against a live S3-compatible server (minio), closing the
  "Storage: no live-cloud test" gap. Opt-in via `CIVIC_TEST_LIVE_S3=1`; hermetic
  CI is unaffected (it skips).
- **Spec-frontmatter CI guard** (`pnpm specs:check` + vitest gate).

### Changed

- **Normalized 68 specs into real top-of-file YAML frontmatter.** They carried a
  malformed jammed single-line metadata block after the title (an artifact of
  `prettier --prose-wrap` reflowing metadata that was never real frontmatter);
  now proper frontmatter (version/status/created/updated), AI-boilerplate
  dropped, `spec:validate` made frontmatter-aware. Finishes the "specs match
  reality" gate.

### Verification

- Browser e2e: 3/3 green locally against real Chromium (incl. Playwright
  auto-starting the UI dev server).
- Live S3: green against minio (`RELEASE.2025-09-07`); the storage suite skips it
  cleanly without the flag (209 passed / 2 skipped).
- Spec tooling: `spec:validate` and `specs:check` both green.
- Full CI (`build-test` + `audit-truth-check` + CodeQL + osv) runs on this PR;
  the new `browser-e2e` job also runs.

### Notes for the reviewer

- Delta over 0.2.1 is intentionally test/quality/docs — the feature substance was
  cut as 0.2.1 (per the earlier conservative-patch call); 0.3.0 formalizes the
  milestone completion.
- Deferred, out of scope (later bands): multi-node realtime scaling, the
  PostgreSQL adapter, geography KML/GPX/Shapefile, multi-channel notifications,
  the "easy deployment" epic (SSG + appliance image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132vSzddyF3htkSPP3W39U9
